### PR TITLE
Fix comments in config files being deleted (#20)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
-use serde::{Serialize, Deserialize};
-use std::fs;
 use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
 
 lazy_static! {
     pub static ref CONFIG: ServerConfig = load_config();
@@ -16,7 +17,7 @@ macro_rules! gen_config {
                 pub $name: $type,
             )*
         }
-        
+
         #[derive(Deserialize)]
         pub struct UnmergedConfig {
             $(
@@ -32,24 +33,35 @@ macro_rules! gen_config {
             }
         }
 
-        fn merge_config(config: UnmergedConfig) -> ServerConfig {
-            let default_config = default_config();
-            ServerConfig {
-                $(
-                    $name: match config.$name {
-                        Some(entry) => entry,
-                        None => default_config.$name
-                    },
-                )*
-            }
-            
+        fn merge_config(config_file: &str) -> Box<dyn Fn(UnmergedConfig) -> ServerConfig> {
+            let config_file = String::from(config_file);
+            Box::new(move |config: UnmergedConfig| -> ServerConfig {
+                    let default_config = default_config();
+                    let mut toml_patch = String::new();
+                    let out = ServerConfig {
+                        $(
+                            $name: match config.$name {
+                                Some(entry) => entry,
+                                None => {
+                                    toml_patch += &format!("{} = {}\n", stringify!($name), default_config.$name);
+                                    default_config.$name
+                                }
+                            },
+                        )*
+                    };
+                    if toml_patch.len() > 0 {
+                        let mut file = fs::OpenOptions::new().append(true).open(&config_file).unwrap();
+                        write!(file, "\n{}", toml_patch).unwrap();
+                    }
+                    out
+            })
         }
     };
 }
 
 gen_config! {
     bind_address: String = "0.0.0.0:25565".to_string(),
-    motd: String = "Minecraft High Performace Redstone Server".to_string(),
+    motd: String = "Minecraft High Performance Redstone Server".to_string(),
     chat_format: String = "<{username}> {message}".to_string(),
     max_players: i64 = 99999,
     bungeecord: bool = false
@@ -62,10 +74,12 @@ fn write_config(config: &ServerConfig) {
 
 fn load_config() -> ServerConfig {
     let config = if let Ok(str) = fs::read_to_string("Config.toml") {
-        toml::from_str(&str).map(merge_config).unwrap_or_else(|_| default_config())
+        toml::from_str(&str)
+            .map(merge_config("Config.toml"))
+            .unwrap_or_else(|_| default_config())
     } else {
+        write_config(&default_config());
         default_config()
     };
-    write_config(&config);
     config
 }


### PR DESCRIPTION
I fixed #20 by changing the config::merge_config function.
It detects which fields are missing from the config and creates a patch for the file, which it then appends to the specified config file.