### PR TITLE
Prevent placement of blocks under the world

### DIFF
--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -62,7 +62,7 @@ impl World for Plot {
         let chunk_index = self.get_chunk_index_for_block(pos.x, pos.z);
 
         // Check to see if block is within height limit
-        if chunk_index >= 256 || pos.y > 256 {
+        if chunk_index >= 256 || pos.y > 256 || pos.y < 0 {
             return false;
         }
 


### PR DESCRIPTION
Today, using MCHPRS worldedit you can place blocks below the world, but
if you do the plot crashes everytime it is loaded, effectively locking
players occupying that plot out until it is deleted.

The relevant line appears to be
   9: mchprs::world::storage::Chunk::encode_packet
        at src/world/storage.rs:347:24

which seems to indicate the Chunk format is failing to encode a packet
whose data includes blocks whose Y value is less than 0.

There is already a check that blocks are not placed above the world, and
in this change I add a check that they are not below the world either.

I tested this to resolve the crash condition when //stack'ing and
//set'ing below the world