### PR TITLE
Add /plot teleport [plot] command

### DIFF
--- a/src/network/packets/clientbound.rs
+++ b/src/network/packets/clientbound.rs
@@ -240,6 +240,7 @@ pub enum CDeclareCommandsNodeParser {
     Float(f32, f32),
     BlockPos,
     BlockState,
+    Greedy,
 }
 
 impl CDeclareCommandsNodeParser {
@@ -264,6 +265,10 @@ impl CDeclareCommandsNodeParser {
                 buf.write_byte(3);
                 buf.write_float(*min);
                 buf.write_float(*max);
+            }
+            Greedy => {
+                buf.write_string(32767, "brigadier:string");
+                buf.write_byte(2); // Read anything after this argument
             }
         }
     }

--- a/src/network/packets/clientbound.rs
+++ b/src/network/packets/clientbound.rs
@@ -235,12 +235,12 @@ impl ClientBoundPacket for CChatMessage {
 
 pub enum CDeclareCommandsNodeParser {
     Entity(i8),
+    Vec2,
     Vec3,
     Integer(i32, i32),
     Float(f32, f32),
     BlockPos,
     BlockState,
-    Greedy,
 }
 
 impl CDeclareCommandsNodeParser {
@@ -251,6 +251,7 @@ impl CDeclareCommandsNodeParser {
                 buf.write_string(32767, "minecraft:entity");
                 buf.write_byte(*flags);
             }
+            Vec2 => buf.write_string(32767, "minecraft:vec2"),
             Vec3 => buf.write_string(32767, "minecraft:vec3"),
             BlockPos => buf.write_string(32767, "minecraft:block_pos"),
             BlockState => buf.write_string(32767, "minecraft:block_state"),
@@ -265,10 +266,6 @@ impl CDeclareCommandsNodeParser {
                 buf.write_byte(3);
                 buf.write_float(*min);
                 buf.write_float(*max);
-            }
-            Greedy => {
-                buf.write_string(32767, "brigadier:string");
-                buf.write_byte(2); // Read anything after this argument
             }
         }
     }

--- a/src/plot/commands.rs
+++ b/src/plot/commands.rs
@@ -65,17 +65,29 @@ impl Plot {
                 }
             }
             "teleport" | "tp" => {
-                if args.is_empty() {
+                if args.len() != 2 {
                     self.players[player].send_error_message("Invalid number of arguments!");
                     return;
                 }
 
-                if let Some((plot_x, plot_z)) = Plot::parse_id(args[0]) {
-                    let center = Plot::get_center(plot_x, plot_z);
-                    self.players[player].teleport(center.0, 64.0, center.1);
+                let plot_x;
+                let plot_z;
+                if let Ok(x_arg) = args[0].parse() {
+                    plot_x = x_arg;
                 } else {
-                    self.players[player].send_error_message(&format!("{} is not a valid plot ID.", args[0]));
+                    self.players[player].send_error_message("Unable to parse x coordinate!");
+                    return;
                 }
+                if let Ok(z_arg) = args[1].parse() {
+                    plot_z = z_arg;
+                } else {
+                    self.players[player].send_error_message("Unable to parse z coordinate!");
+                    return;
+                }
+
+                let center = Plot::get_center(plot_x, plot_z);
+                self.players[player].teleport(center.0, 64.0, center.1);
+                return;
             }
             _ => self.players[player].send_error_message("Invalid argument for /plot"),
         }
@@ -262,10 +274,6 @@ impl Plot {
                     if speed_arg < 0.0 {
                         self.players[player]
                             .send_error_message("Silly child, you can't have a negative flyspeed");
-                        return false;
-                    } else if speed_arg > 10.0 {
-                        self.players[player]
-                            .send_error_message("You cannot have a flyspeed greater than 10");
                         return false;
                     }
                     self.players[player].fly_speed = speed_arg;
@@ -675,13 +683,13 @@ lazy_static! {
                 name: Some("teleport"),
                 parser: None,
             },
-            // 45: /p teleport [plotid]
+            // 45: /p teleport [x, z]
             Node {
                 flags: (CommandFlags::ARGUMENT | CommandFlags::EXECUTABLE).bits() as i8,
                 children: vec![],
                 redirect_node: None,
-                name: Some("plotid"),
-                parser: Some(Parser::Greedy),
+                name: Some("x, z"),
+                parser: Some(Parser::Vec2),
             },
             // 46: /p tp
             Node {

--- a/src/plot/commands.rs
+++ b/src/plot/commands.rs
@@ -64,6 +64,19 @@ impl Plot {
                     self.players[player].send_system_message(&format!("{} does not own any plots.", args[0]));
                 }
             }
+            "teleport" | "tp" => {
+                if args.is_empty() {
+                    self.players[player].send_error_message("Invalid number of arguments!");
+                    return;
+                }
+
+                if let Some((plot_x, plot_z)) = Plot::parse_id(args[0]) {
+                    let center = Plot::get_center(plot_x, plot_z);
+                    self.players[player].teleport(center.0, 64.0, center.1);
+                } else {
+                    self.players[player].send_error_message(&format!("{} is not a valid plot ID.", args[0]));
+                }
+            }
             _ => self.players[player].send_error_message("Invalid argument for /plot"),
         }
     }
@@ -353,7 +366,7 @@ lazy_static! {
             // 6: /plot
             Node {
                 flags: (CommandFlags::LITERAL).bits() as i8,
-                children: vec![7, 8, 9, 10, 38, 39, 40, 41, 43],
+                children: vec![7, 8, 9, 10, 38, 39, 40, 41, 43, 44, 46],
                 redirect_node: None,
                 name: Some("plot"),
                 parser: None,
@@ -652,6 +665,30 @@ lazy_static! {
                 children: vec![],
                 redirect_node: Some(41),
                 name: Some("v"),
+                parser: None,
+            },
+            // 44: /p teleport
+            Node {
+                flags: (CommandFlags::LITERAL).bits() as i8,
+                children: vec![45],
+                redirect_node: None,
+                name: Some("teleport"),
+                parser: None,
+            },
+            // 45: /p teleport [plotid]
+            Node {
+                flags: (CommandFlags::ARGUMENT | CommandFlags::EXECUTABLE).bits() as i8,
+                children: vec![],
+                redirect_node: None,
+                name: Some("plotid"),
+                parser: Some(Parser::Greedy),
+            },
+            // 46: /p tp
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::REDIRECT).bits() as i8,
+                children: vec![],
+                redirect_node: Some(44),
+                name: Some("tp"),
                 parser: None,
             },
         ],

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -523,6 +523,15 @@ impl Plot {
         }
     }
 
+    /// Parses a plot ID of the form "x,z" into the x, z coordinates it
+    /// specifies, or None if the id is invalid.
+    fn parse_id(arg: &str) -> Option<(i32, i32)> {
+        let (x, z) = arg.split_once(',')?;
+        let x = x.parse().ok()?;
+        let z = z.parse().ok()?;
+        Some((x, z))
+    }
+
     fn handle_commands(&mut self) {
         let mut removal_offset = 0;
         for player_idx in 0..self.players.len() {

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -523,15 +523,6 @@ impl Plot {
         }
     }
 
-    /// Parses a plot ID of the form "x,z" into the x, z coordinates it
-    /// specifies, or None if the id is invalid.
-    fn parse_id(arg: &str) -> Option<(i32, i32)> {
-        let (x, z) = arg.split_once(',')?;
-        let x = x.parse().ok()?;
-        let z = z.parse().ok()?;
-        Some((x, z))
-    }
-
     fn handle_commands(&mut self) {
         let mut removal_offset = 0;
         for player_idx in 0..self.players.len() {


### PR DESCRIPTION
This adds the ability to teleport to an arbitrary plot by its x,z "id"

This change also adds a new completion parser, "Greedy", which
corresponds to `brigadier:string` with flags indicating that it accepts
anything from the argument to the end of the line. This is necessary
because the plot id doesn't seem to be anything Minecraft can parse by
itself, and is you use `brigadier:string` in "one word" mode, the parser
believes the argument ends at the comma and shows an error for valid
input.

I use the "x,z" format to match plotsquared's command API, but if people
don't like that it's easy enough to swap out for separate arguments.

I mostly wanted to move `parse_id` out into a separate function because
without access to `?` parsing that was starting to get ugly.