### PR TITLE
Add worldedit //shift command

### DIFF
--- a/src/plot/commands.rs
+++ b/src/plot/commands.rs
@@ -326,7 +326,7 @@ lazy_static! {
             // 0: Root Node
             Node {
                 flags: CommandFlags::ROOT.bits() as i8,
-                children: vec![1, 4, 5, 6, 11, 12, 14, 16, 18, 19, 20, 21, 22, 23, 24, 26, 29, 31, 32, 34, 36],
+                children: vec![1, 4, 5, 6, 11, 12, 14, 16, 18, 19, 20, 21, 22, 23, 24, 26, 29, 31, 32, 34, 36, 47],
                 redirect_node: None,
                 name: None,
                 parser: None,
@@ -698,6 +698,22 @@ lazy_static! {
                 redirect_node: Some(44),
                 name: Some("tp"),
                 parser: None,
+            },
+            // 47: //shift
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: vec![35],
+                redirect_node: None,
+                name: Some("/shift"),
+                parser: None,
+            },
+            // 48: //shift [amount]
+            Node {
+                flags: (CommandFlags::ARGUMENT | CommandFlags::EXECUTABLE).bits() as i8,
+                children: vec![],
+                redirect_node: None,
+                name: Some("amount"),
+                parser: Some(Parser::Integer(0, 256)),
             },
         ],
         root_index: 0

--- a/src/plot/worldedit/mod.rs
+++ b/src/plot/worldedit/mod.rs
@@ -472,6 +472,16 @@ lazy_static! {
             description: "Contract the selection area",
             ..Default::default()
         },
+        "/shift" => WorldeditCommand {
+            arguments: &[
+                argument!("amount", UnsignedInteger, "Amount to shift the selection by"),
+                argument!("direction", Direction, "Direction to shift")
+            ],
+            requires_positions: true,
+            execute_fn: execute_shift,
+            description: "Shift the selection area",
+            ..Default::default()
+        },
         "/help" => WorldeditCommand {
             arguments: &[
                 argument!("command", String, "Command to retrieve help for"),
@@ -1424,6 +1434,30 @@ fn execute_contract(mut ctx: CommandExecuteContext<'_>) {
     }
 
     player.send_worldedit_message(&format!("Region expanded {} block(s).", amount));
+}
+
+fn execute_shift(mut ctx: CommandExecuteContext<'_>) {
+    let amount = ctx.arguments[0].unwrap_uint();
+    let direction = ctx.arguments[1].unwrap_direction();
+    let player = ctx.get_player_mut();
+    let first_pos = player.first_position.unwrap();
+    let second_pos = player.second_position.unwrap();
+
+    let mut move_both_points = |x, y, z| {
+        player.worldedit_set_first_position(BlockPos::new(first_pos.x + x, first_pos.y + y, first_pos.z + z));
+        player.worldedit_set_second_position(BlockPos::new(second_pos.x + x, second_pos.y + y, second_pos.z + z));
+    };
+
+    match direction {
+        BlockFacing::Up => move_both_points(0, amount as i32, 0),
+        BlockFacing::Down => move_both_points(0, -(amount as i32), 0),
+        BlockFacing::East => move_both_points(amount as i32, 0, 0),
+        BlockFacing::West => move_both_points(-(amount as i32), 0, 0),
+        BlockFacing::South => move_both_points(0, 0, amount as i32),
+        BlockFacing::North => move_both_points(0, 0, -(amount as i32)),
+    }
+
+    player.send_worldedit_message(&format!("Region shifted {} block(s).", amount));
 }
 
 fn execute_help(mut ctx: CommandExecuteContext<'_>) {


### PR DESCRIPTION
This duplicates a behavior of the original WorldEdit mod that I use a
lot, to shift both points of a selection by a number of blocks without
moving anything.

Mechanically, this is based significantly on //expand, with just a
different interior function that moves both points instead of one.