### PR TITLE
Implement CSetSlot, respond to CreativeInventoryAction

### DIFF
--- a/src/network/packets/clientbound.rs
+++ b/src/network/packets/clientbound.rs
@@ -359,7 +359,7 @@ impl ClientBoundPacket for CSetSlot {
         } else {
             buf.write_bool(false);
         }
-        PacketEncoder::new(buf, 0x15)
+        PacketEncoder::new(buf, 0x16)
     }
 }
 

--- a/src/network/packets/clientbound.rs
+++ b/src/network/packets/clientbound.rs
@@ -337,6 +337,32 @@ impl ClientBoundPacket for CWindowItems {
     }
 }
 
+pub struct CSetSlot {
+    pub slot: i16,
+    pub slot_data: Option<SlotData>,
+}
+
+impl ClientBoundPacket for CSetSlot {
+    fn encode(self) -> PacketEncoder {
+        let mut buf = Vec::new();
+        buf.write_byte(0);
+        buf.write_short(self.slot);
+        if let Some(slot) = self.slot_data {
+            buf.write_bool(true);
+            buf.write_varint(slot.item_id);
+            buf.write_byte(slot.item_count);
+            if let Some(nbt) = slot.nbt {
+                buf.write_nbt_blob(nbt);
+            } else {
+                buf.write_byte(0); // End tag
+            }
+        } else {
+            buf.write_bool(false);
+        }
+        PacketEncoder::new(buf, 0x15)
+    }
+}
+
 pub struct CPluginMessage {
     pub channel: String,
     pub data: Vec<u8>,

--- a/src/network/packets/serverbound.rs
+++ b/src/network/packets/serverbound.rs
@@ -432,6 +432,7 @@ impl ServerBoundPacket for SCreativeInventoryAction {
         } else {
             None
         };
+
         Ok(SCreativeInventoryAction { slot, clicked_item })
     }
 


### PR DESCRIPTION
The client sometimes doesn't update its inventory unless the server says it should. When the client sends a flood of CreativeInventoryAction packets due to shift-clicking the "Destroy Item" button in creative mode, the client won't actually remove the items from the inventory until the server tells it to.

This PR conflicts with https://github.com/MCHPR/MCHPRS/pull/43. If you're gonna merge that PR, it's probably a good idea to do that PR first, then I'll rebase and update this PR to work with the new clientbound packets system