### PR TITLE
Enable the schemati option by default.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,6 @@ gen_config! {
     max_players: i64 = 99999,
     bungeecord: bool = false,
     whitelist: bool = false,
-    schemati: bool = false,
+    schemati: bool = true,
     luckperms: Option<PermissionsConfig> = None
 }


### PR DESCRIPTION
This prevents potential attacks like `//load ../filename` and
`//save ../filename`.