### PR TITLE
Remove use of nightly features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "mchprs_world",
  "md5",
  "mysql",
+ "once_cell",
  "rand",
  "rayon",
  "redpiler_graph",
@@ -1550,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oorandom"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ If the Rust compiler is not already installed, you can find out how [on their of
 ```shell
 git clone https://github.com/MCHPR/MCHPRS.git
 cd MCHPRS
-rustup override set nightly
 cargo build --release
 ```
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 fern = { version = "0.6", features = ["colored"] }
 chrono = "0.4"
 rand = "0.8"
-regex = { version = "1.4", features = ["pattern"] }
+regex = { version = "1.4" }
 backtrace = "0.3"
 rusqlite = { version="0.27", features=["bundled"] }
 anyhow = "1.0"
@@ -46,6 +46,7 @@ reqwest = { version = "0.11", features = ["json"] }
 itertools = "0.10"
 impls = "1"
 bincode = "1.3"
+once_cell = "1.14.0"
 redpiler_graph = { path = "../redpiler_graph" }
 mchprs_save_data = { path = "../save_data" }
 mchprs_blocks = { path = "../blocks" }

--- a/crates/core/src/blocks/mod.rs
+++ b/crates/core/src/blocks/mod.rs
@@ -47,10 +47,29 @@ trait BlockTransform {
     fn flip(&mut self, dir: crate::blocks::FlipDirection);
 }
 
-impl<T> BlockTransform for T {
-    default fn rotate90(&mut self) {}
-    default fn flip(&mut self, _dir: crate::blocks::FlipDirection) {}
+macro_rules! noop_block_transform {
+    ($($ty:ty),*$(,)?) => {
+        $(
+            impl BlockTransform for $ty {
+                fn rotate90(&mut self) {}
+                fn flip(&mut self, dir: crate::blocks::FlipDirection) {}
+            }
+        )*
+    };
 }
+
+noop_block_transform!(
+    u8,
+    u32,
+    bool,
+    BlockColorVariant,
+    BlockFacing,
+    TrapdoorHalf,
+    SignType,
+    redstone::ButtonFace,
+    redstone::LeverFace,
+    redstone::ComparatorMode,
+);
 
 impl BlockTransform for BlockDirection {
     fn flip(&mut self, dir: FlipDirection) {

--- a/crates/core/src/chat.rs
+++ b/crates/core/src/chat.rs
@@ -1,8 +1,8 @@
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
-use std::sync::LazyLock;
 
-static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+static URL_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new("([a-zA-Z0-9§\\-:/]+\\.[a-zA-Z/0-9§\\-:_#]+(\\.[a-zA-Z/0-9.§\\-:#\\?\\+=_]+)?)")
         .unwrap()
 });
@@ -220,7 +220,10 @@ impl ChatComponent {
         for component in components {
             let mut last = 0;
             let text = &component.text;
-            for (index, matched) in text.match_indices(&*URL_REGEX) {
+
+            for match_ in URL_REGEX.find_iter(text) {
+                let index = match_.start();
+                let matched = match_.as_str();
                 if last != index {
                     let mut new = component.clone();
                     new.text = String::from(&text[last..index]);

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,11 +1,11 @@
 use crate::permissions::PermissionsConfig;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
-use std::sync::LazyLock;
 use toml_edit::{value, Document};
 
-pub static CONFIG: LazyLock<ServerConfig> = LazyLock::new(|| ServerConfig::load("Config.toml"));
+pub static CONFIG: Lazy<ServerConfig> = Lazy::new(|| ServerConfig::load("Config.toml"));
 
 trait ConfigSerializeDefault {
     fn fix_config(self, name: &str, doc: &mut Document);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(rust_2018_idioms)]
-#![feature(min_specialization, once_cell)]
 
 #[macro_use]
 mod utils;

--- a/crates/core/src/permissions/mod.rs
+++ b/crates/core/src/permissions/mod.rs
@@ -3,10 +3,10 @@ use crate::utils::HyphenatedUUID;
 use anyhow::{anyhow, Context, Result};
 use mysql::prelude::*;
 use mysql::{OptsBuilder, Pool, PooledConn, Row};
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::sync::OnceLock;
 
-static POOL: OnceLock<Pool> = OnceLock::new();
+static POOL: OnceCell<Pool> = OnceCell::new();
 
 fn conn() -> Result<PooledConn> {
     Ok(POOL

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -15,9 +15,9 @@ use mchprs_network::packets::clientbound::{
 use mchprs_network::packets::PacketEncoder;
 use mchprs_network::PlayerPacketSender;
 use mchprs_save_data::plot_data::Tps;
+use once_cell::sync::Lazy;
 use std::ops::Add;
 use std::str::FromStr;
-use std::sync::LazyLock;
 use std::time::Instant;
 
 // Parses a relative or absolute coordinate relative to a reference coordinate
@@ -497,7 +497,7 @@ bitflags! {
 // For more information, see https://wiki.vg/Command_Data
 /// The `DeclareCommands` packet that is sent when the player joins.
 /// This is used for command autocomplete.
-pub static DECLARE_COMMANDS: LazyLock<PacketEncoder> = LazyLock::new(|| {
+pub static DECLARE_COMMANDS: Lazy<PacketEncoder> = Lazy::new(|| {
     CDeclareCommands {
         nodes: &[
             // 0: Root Node

--- a/crates/core/src/plot/data.rs
+++ b/crates/core/src/plot/data.rs
@@ -1,8 +1,8 @@
 use super::{Plot, PlotWorld, PLOT_WIDTH};
 use anyhow::{Context, Result};
 use mchprs_save_data::plot_data::{ChunkData, PlotData, Tps};
+use once_cell::sync::Lazy;
 use std::path::Path;
-use std::sync::LazyLock;
 use std::time::Duration;
 
 // TODO: where to put this?
@@ -33,7 +33,7 @@ pub fn empty_plot() -> PlotData {
     EMPTY_PLOT.clone()
 }
 
-static EMPTY_PLOT: LazyLock<PlotData> = LazyLock::new(|| {
+static EMPTY_PLOT: Lazy<PlotData> = Lazy::new(|| {
     let template_path = Path::new("./world/plots/pTEMPLATE");
     if template_path.exists() {
         PlotData::load_from_file(template_path).expect("failed to read template plot")

--- a/crates/core/src/plot/database.rs
+++ b/crates/core/src/plot/database.rs
@@ -1,7 +1,8 @@
+use once_cell::sync::Lazy;
 use rusqlite::{params, Connection};
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard};
 
-static CONN: LazyLock<Mutex<Connection>> = LazyLock::new(|| {
+static CONN: Lazy<Mutex<Connection>> = Lazy::new(|| {
     Mutex::new(Connection::open("./world/plots.db").expect("Error opening plot database!"))
 });
 

--- a/crates/core/src/plot/worldedit/execute.rs
+++ b/crates/core/src/plot/worldedit/execute.rs
@@ -10,6 +10,7 @@ use mchprs_blocks::items::{Item, ItemStack};
 use mchprs_blocks::{BlockFace, BlockFacing, BlockPos};
 use mchprs_network::packets::clientbound::*;
 use mchprs_network::packets::SlotData;
+use once_cell::sync::Lazy;
 use schematic::{load_schematic, save_schematic};
 use std::time::Instant;
 
@@ -252,8 +253,8 @@ pub(super) fn execute_paste(ctx: CommandExecuteContext<'_>) {
     }
 }
 
-static SCHEMATI_VALIDATE_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"[a-zA-Z0-9_.]+\.schem(atic)?").unwrap());
+static SCHEMATI_VALIDATE_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[a-zA-Z0-9_.]+\.schem(atic)?").unwrap());
 
 pub(super) fn execute_load(mut ctx: CommandExecuteContext<'_>) {
     let start_time = Instant::now();

--- a/crates/core/src/plot/worldedit/mod.rs
+++ b/crates/core/src/plot/worldedit/mod.rs
@@ -12,13 +12,13 @@ use execute::*;
 use mchprs_blocks::block_entities::{BlockEntity, ContainerType};
 use mchprs_blocks::{BlockFacing, BlockPos};
 use mchprs_utils::map;
+use once_cell::sync::Lazy;
 use rand::Rng;
 use regex::Regex;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
-use std::sync::LazyLock;
 
 // Attempts to execute a worldedit command. Returns true of the command was handled.
 // The command is not handled if it is not found in the worldedit commands and alias lists.
@@ -433,7 +433,7 @@ impl Default for WorldeditCommand {
     }
 }
 
-static COMMANDS: LazyLock<HashMap<&'static str, WorldeditCommand>> = LazyLock::new(|| {
+static COMMANDS: Lazy<HashMap<&'static str, WorldeditCommand>> = Lazy::new(|| {
     map! {
         "up" => WorldeditCommand {
             execute_fn: execute_up,
@@ -727,7 +727,7 @@ static COMMANDS: LazyLock<HashMap<&'static str, WorldeditCommand>> = LazyLock::n
     }
 });
 
-static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+static ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     map! {
         "u" => "up",
         "desc" => "descend",
@@ -803,7 +803,7 @@ impl FromStr for WorldEditPattern {
     fn from_str(pattern_str: &str) -> PatternParseResult<WorldEditPattern> {
         let mut pattern = WorldEditPattern { parts: Vec::new() };
         for part in pattern_str.split(',') {
-            static RE: LazyLock<Regex> = LazyLock::new(|| {
+            static RE: Lazy<Regex> = Lazy::new(|| {
                 Regex::new(r"^(([0-9]+(\.[0-9]+)?)%)?(=)?([0-9]+|(minecraft:)?[a-zA-Z_]+)(:([0-9]+)|\[(([a-zA-Z_]+=[a-zA-Z0-9]+,?)+?)\])?((\|([^|]*?)){1,4})?$").unwrap()
             });
 

--- a/crates/core/src/plot/worldedit/schematic.rs
+++ b/crates/core/src/plot/worldedit/schematic.rs
@@ -9,12 +9,12 @@ use anyhow::{bail, Context, Result};
 use itertools::Itertools;
 use mchprs_blocks::block_entities::BlockEntity;
 use mchprs_blocks::BlockPos;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::PathBuf;
-use std::sync::LazyLock;
 
 macro_rules! nbt_as {
     // I'm not sure if path is the right type here.
@@ -28,8 +28,8 @@ macro_rules! nbt_as {
 }
 
 fn parse_block(str: &str) -> Option<Block> {
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?:minecraft:)?([a-z_]+)(?:\[([a-z=,0-9]+)\])?").unwrap());
+    static RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?:minecraft:)?([a-z_]+)(?:\[([a-z=,0-9]+)\])?").unwrap());
     let captures = RE.captures(str)?;
     let mut block = Block::from_name(captures.get(1)?.as_str()).unwrap_or(Block::Air {});
     if let Some(properties_match) = captures.get(2) {


### PR DESCRIPTION

* Removed dependency on `regex`'s `pattern` feature: `find_iter` already does what is needed.
* Replacing a specialized default blanket impl with a macro that generates the impl (so types need to be manually added to implement `BlockTransform`) This is more correct because when new blocks are added that need to implement `BlockTransform`, someone could forget to implement and it will just fallback to the blanket impl instead (previous behavior) After this change any new types do not get `BlockTransform` automatically and an impl must be added manually.
* Replaced the std `once_cell` feature with the `once_cell` crate. As shown in `Cargo.lock`, this is already one of the transitive dependencies, so adding this as a dependency will not introduce more bloat.