### PR TITLE
More efficient Redpiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "smallvec",
  "tokio",
  "toml",
  "toml_edit",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,6 +46,7 @@ reqwest = { version = "0.11", features = ["json"] }
 itertools = "0.10"
 impls = "1"
 bincode = "1.3"
+smallvec = "1.9.0"
 redpiler_graph = { path = "../redpiler_graph" }
 mchprs_save_data = { path = "../save_data" }
 mchprs_blocks = { path = "../blocks" }

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -138,7 +138,7 @@ pub struct Node {
     ty: NodeType,
     default_inputs: SmallVec<[DirectLink; 2]>,
     side_inputs: SmallVec<[DirectLink; 1]>,
-    updates: Vec<NodeId>,
+    updates: SmallVec<[NodeId; 2]>,
     facing_diode: bool,
     comparator_far_input: Option<u8>,
 

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -81,7 +81,7 @@ mod nodes {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct DirectLink {
     weight: u8,
     to: NodeId,
@@ -492,13 +492,14 @@ fn schedule_tick(
     scheduler.schedule_tick(node_id, delay, priority);
 }
 
-fn link_strength(link: &DirectLink, nodes: &Nodes) -> u8 {
+fn link_strength(link: DirectLink, nodes: &Nodes) -> u8 {
     nodes[link.to].output_power.saturating_sub(link.weight)
 }
 
 fn get_bool_input(node: &Node, nodes: &Nodes) -> bool {
     node.default_inputs
         .iter()
+        .copied()
         .any(|link| link_strength(link, nodes) > 0)
 }
 
@@ -506,6 +507,7 @@ fn get_all_input(node: &Node, nodes: &Nodes) -> (u8, u8) {
     let input_power = node
         .default_inputs
         .iter()
+        .copied()
         .map(|link| link_strength(link, nodes))
         .max()
         .unwrap_or(0);
@@ -513,6 +515,7 @@ fn get_all_input(node: &Node, nodes: &Nodes) -> (u8, u8) {
     let side_input_power = node
         .side_inputs
         .iter()
+        .copied()
         .map(|link| link_strength(link, nodes))
         .max()
         .unwrap_or(0);

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -5,7 +5,6 @@ use crate::blocks::{Block, ComparatorMode, RedstoneRepeater};
 use crate::plot::PlotWorld;
 use crate::redpiler::{block_powered_mut, bool_to_ss, CompileNode, LinkType};
 use crate::world::World;
-use itertools::Itertools;
 use log::warn;
 use mchprs_blocks::block_entities::BlockEntity;
 use mchprs_blocks::BlockPos;
@@ -13,6 +12,7 @@ use mchprs_world::{TickEntry, TickPriority};
 use nodes::{NodeId, Nodes};
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
+use smallvec::SmallVec;
 
 mod nodes {
     use super::Node;
@@ -136,8 +136,8 @@ impl NodeType {
 #[derive(Debug, Clone)]
 pub struct Node {
     ty: NodeType,
-    default_inputs: Vec<DirectLink>,
-    side_inputs: Vec<DirectLink>,
+    default_inputs: SmallVec<[DirectLink; 2]>,
+    side_inputs: SmallVec<[DirectLink; 1]>,
     updates: Vec<NodeId>,
     facing_diode: bool,
     comparator_far_input: Option<u8>,
@@ -155,8 +155,8 @@ impl Node {
     fn from_compile_node(node: CompileNode, nodes_len: usize) -> Self {
         let output_power = node.output_power();
         let powered = node.powered();
-        let mut default_inputs = vec![];
-        let mut side_inputs = vec![];
+        let mut default_inputs = SmallVec::new();
+        let mut side_inputs = SmallVec::new();
         node.inputs
             .into_iter()
             .map(|link| {

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -12,7 +12,7 @@ use mchprs_world::{TickEntry, TickPriority};
 use nodes::{NodeId, Nodes};
 use smallvec::SmallVec;
 use std::collections::{HashMap, VecDeque};
-use std::fmt;
+use std::{fmt, mem};
 
 mod nodes {
     use super::Node;
@@ -253,9 +253,7 @@ impl TickScheduler {
         if self.queues_deque.len() == 0 {
             self.queues_deque.push_back(Default::default());
         }
-        let queues = self.queues_deque.pop_front().unwrap();
-        self.queues_deque.push_front(Default::default());
-        queues
+        mem::take(&mut self.queues_deque[0])
     }
 
     fn end_tick(&mut self, mut queues: Queues) {


### PR DESCRIPTION
I improved the performance of the Redpiler (`direct` backend).
On my machine it now runs ~50% faster.

`chungus-mandelbrot-tick` benchmark went from 12.5μs down to 8.3μs and `chungus-mandelbrot-full` from 153s down to 100s.

Though I have not done an exhaustive correctness check, it does still render the mandelbrot correctly.