### PR TITLE
Fixed Trapdoor Rotation

### DIFF
--- a/crates/blocks/src/lib.rs
+++ b/crates/blocks/src/lib.rs
@@ -348,6 +348,16 @@ impl BlockFacing {
         }
     }
 
+    pub fn from_id_trapdoor(id: u32) -> BlockFacing{
+        match id {
+            0 => BlockFacing::North,
+            1 => BlockFacing::South,
+            2 => BlockFacing::West,
+            3 => BlockFacing::East,
+            _ => BlockFacing::North,
+        }
+    }
+
     pub fn get_id(self) -> u32 {
         match self {
             BlockFacing::North => 0,
@@ -356,6 +366,16 @@ impl BlockFacing {
             BlockFacing::West => 3,
             BlockFacing::Up => 4,
             BlockFacing::Down => 5,
+        }
+    }
+
+    pub fn get_id_trapdoor(self) -> u32 {
+        match self {
+            BlockFacing::North => 0,
+            BlockFacing::South => 1,
+            BlockFacing::West => 2,
+            BlockFacing::East => 3,
+            _ => 0,
         }
     }
 

--- a/crates/core/src/blocks/mod.rs
+++ b/crates/core/src/blocks/mod.rs
@@ -1676,14 +1676,14 @@ blocks! {
             powered: bool
         },
         get_id: {
-            facing.get_id() * 16
+            facing.get_id_trapdoor() * 16
                 + half.get_id() * 8
                 + !powered as u32 * 6
                 + 7788
         },
         from_id_offset: 7788,
         from_id(id): 7788..=7850 => {
-            facing: BlockFacing::from_id(id >> 4),
+            facing: BlockFacing::from_id_trapdoor(id >> 4),
             half: TrapdoorHalf::from_id((id >> 3) & 1),
             powered: ((id >> 1) & 1) == 0
         },


### PR DESCRIPTION
Previously Trapdoor rotation was not working because the order of directions for the block id is different for trapdoors than for normal blocks.

Normal Blocks:
```json
      "facing": [
        "north",
        "east",
        "south",
        "west",
        "up",
        "down"
      ]
```

Trapdoors;
```json
      "facing": [
        "north",
        "south",
        "west",
        "east"
      ]
```