### PR TITLE
Tell rustup to automatically use the nightly channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ If the Rust compiler is not already installed, you can find out how [on their of
 ```shell
 git clone https://github.com/MCHPR/MCHPRS.git
 cd MCHPRS
-rustup override set nightly
 cargo build --release
 ```
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Since MCHPRS only compiles using rust nightly, it can ship a `rust-toolchain` file that will tell rustup to automatically switch to the nightly channel.

This behavior is documented here:
https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

This also prevents you needing to provide instructions to add a manual override in the README.