### PR TITLE
Generic Redpiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1337,7 @@ dependencies = [
  "cranelift-module",
  "criterion",
  "ctrlc",
+ "enum_dispatch",
  "hematite-nbt",
  "impls",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ include = [
 # MCHPRS runs far too slow without any optimizations to even be usable for testing
 opt-level = 1
 
+[profile.release]
+# This seems to speed up Redpiler compile times
+lto = "fat"
+
 [dependencies]
 mchprs_core = { path = "./crates/core" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,7 @@ harness = false
 [dependencies]
 mchprs_proc_macros = { path = "../proc_macros" }
 toml = "0.7"
+enum_dispatch = "0.3"
 byteorder = "1.4"
 hematite-nbt = "0.5"
 bitflags = "1.2"

--- a/crates/core/benches/chungus.rs
+++ b/crates/core/benches/chungus.rs
@@ -28,12 +28,13 @@ fn load_world(path: impl AsRef<Path>) -> PlotWorld {
     }
 }
 
-fn init_compiler() -> (PlotWorld, Compiler) {
+fn init_compiler() -> (PlotWorld, Compiler<PlotWorld>) {
     let mut world = load_world("./benches/chungus_mandelbrot_plot");
-    let mut compiler: Compiler = Default::default();
+    let mut compiler: Compiler<PlotWorld> = Default::default();
 
     let options = CompilerOptions::parse("-O");
-    compiler.compile(&mut world, options, Vec::new());
+    let bounds = world.get_corners();
+    compiler.compile(&mut world, bounds, options, Vec::new());
     compiler.on_use_block(&mut world, START_BUTTON);
     (world, compiler)
 }

--- a/crates/core/benches/chungus.rs
+++ b/crates/core/benches/chungus.rs
@@ -28,22 +28,22 @@ fn load_world(path: impl AsRef<Path>) -> PlotWorld {
     }
 }
 
-fn init_compiler() -> (PlotWorld, Compiler<PlotWorld>) {
+fn init_compiler() -> Compiler {
     let mut world = load_world("./benches/chungus_mandelbrot_plot");
-    let mut compiler: Compiler<PlotWorld> = Default::default();
+    let mut compiler: Compiler = Default::default();
 
     let options = CompilerOptions::parse("-O");
     let bounds = world.get_corners();
     compiler.compile(&mut world, bounds, options, Vec::new());
-    compiler.on_use_block(&mut world, START_BUTTON);
-    (world, compiler)
+    compiler.on_use_block(START_BUTTON);
+    compiler
 }
 
 fn chungus_mandelbrot(c: &mut Criterion) {
-    let (mut world, mut compiler) = init_compiler();
+    let mut compiler = init_compiler();
 
     c.bench_function("chungus-mandelbrot-tick", |b| {
-        b.iter(|| compiler.tick(&mut world));
+        b.iter(|| compiler.tick());
     });
 }
 
@@ -55,10 +55,10 @@ fn mandelbrot_full(_c: &mut Criterion) {
     }
 
     println!("Running full chungus mandelbrot, this can take a while!");
-    let (mut world, mut compiler) = init_compiler();
+    let mut compiler = init_compiler();
     let start = Instant::now();
     for _ in 0..12411975 {
-        compiler.tick(&mut world);
+        compiler.tick();
     }
     println!("Mandelbrot benchmark completed in {:?}", start.elapsed());
 }

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -53,7 +53,7 @@ pub const WORLD_SEND_RATE: Duration = Duration::from_millis(15);
 pub struct Plot {
     pub world: PlotWorld,
     pub players: Vec<Player>,
-    pub redpiler: Compiler<PlotWorld>,
+    pub redpiler: Compiler,
 
     // Thread communication
     message_receiver: BusReader<BroadcastMessage>,
@@ -243,7 +243,7 @@ impl Plot {
     fn tick(&mut self) {
         self.timings.tick();
         if self.redpiler.is_active() {
-            self.redpiler.tick(&mut self.world);
+            self.redpiler.tick();
             return;
         }
 
@@ -318,7 +318,7 @@ impl Plot {
     fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool) {
         if self.redpiler.is_active() {
             self.redpiler
-                .set_pressure_plate(&mut self.world, pos, powered);
+                .set_pressure_plate(pos, powered);
             return;
         }
 

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -53,7 +53,7 @@ pub const WORLD_SEND_RATE: Duration = Duration::from_millis(15);
 pub struct Plot {
     pub world: PlotWorld,
     pub players: Vec<Player>,
-    pub redpiler: Compiler,
+    pub redpiler: Compiler<PlotWorld>,
 
     // Thread communication
     message_receiver: BusReader<BroadcastMessage>,
@@ -529,7 +529,9 @@ impl Plot {
             .set_redpiler_state(&self.players, RedpilerState::Compiling);
         self.scoreboard
             .set_redpiler_options(&self.players, &options);
-        self.redpiler.compile(&mut self.world, options, ticks);
+        let bounds = self.world.get_corners();
+        self.redpiler
+            .compile(&mut self.world, bounds, options, ticks);
         self.scoreboard
             .set_redpiler_state(&self.players, RedpilerState::Running);
 
@@ -540,7 +542,8 @@ impl Plot {
     fn reset_redpiler(&mut self) {
         if self.redpiler.is_active() {
             debug!("Discarding redpiler");
-            self.redpiler.reset(&mut self.world);
+            let bounds = self.world.get_corners();
+            self.redpiler.reset(&mut self.world, bounds);
             self.scoreboard
                 .set_redpiler_state(&self.players, RedpilerState::Stopped);
             self.scoreboard

--- a/crates/core/src/plot/packet_handlers.rs
+++ b/crates/core/src/plot/packet_handlers.rs
@@ -226,7 +226,7 @@ impl ServerBoundPacketHandler for Plot {
             let block = self.world.get_block(block_pos);
             let lever_or_button = matches!(block, Block::Lever { .. } | Block::StoneButton { .. });
             if lever_or_button && !self.players[player].crouching {
-                self.redpiler.on_use_block(&mut self.world, block_pos);
+                self.redpiler.on_use_block(block_pos);
                 return;
             } else {
                 match self.redpiler.current_flags() {

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -329,7 +329,7 @@ impl DirectBackend {
     }
 }
 
-impl<W: World> JITBackend<W> for DirectBackend {
+impl JITBackend for DirectBackend {
     fn inspect(&mut self, pos: BlockPos) {
         let Some(node_id) = self.pos_map.get(&pos) else {
             debug!("could not find node at pos {}", pos);
@@ -339,7 +339,7 @@ impl<W: World> JITBackend<W> for DirectBackend {
         debug!("Node {:?}: {:#?}", node_id, self.nodes[*node_id]);
     }
 
-    fn reset(&mut self, world: &mut W, io_only: bool) {
+    fn reset<W: World>(&mut self, world: &mut W, io_only: bool) {
         self.scheduler.reset(world, &self.blocks);
 
         let nodes = std::mem::take(&mut self.nodes);
@@ -363,7 +363,7 @@ impl<W: World> JITBackend<W> for DirectBackend {
         self.pos_map.clear();
     }
 
-    fn on_use_block(&mut self, _world: &mut W, pos: BlockPos) {
+    fn on_use_block(&mut self, pos: BlockPos) {
         let node_id = self.pos_map[&pos];
         let node = &self.nodes[node_id];
         match node.ty {
@@ -381,7 +381,7 @@ impl<W: World> JITBackend<W> for DirectBackend {
         }
     }
 
-    fn set_pressure_plate(&mut self, _world: &mut W, pos: BlockPos, powered: bool) {
+    fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool) {
         let node_id = self.pos_map[&pos];
         let node = &self.nodes[node_id];
         match node.ty {
@@ -392,7 +392,7 @@ impl<W: World> JITBackend<W> for DirectBackend {
         }
     }
 
-    fn tick(&mut self, _world: &mut W) {
+    fn tick(&mut self) {
         let mut queues = self.scheduler.queues_this_tick();
 
         for node_id in queues.drain_iter() {
@@ -508,7 +508,7 @@ impl<W: World> JITBackend<W> for DirectBackend {
         // println!("{}", self);
     }
 
-    fn flush(&mut self, world: &mut W, io_only: bool) {
+    fn flush<W: World>(&mut self, world: &mut W, io_only: bool) {
         for (i, node) in self.nodes.inner_mut().iter_mut().enumerate() {
             let Some((pos, block)) = &mut self.blocks[i] else {
                 continue;

--- a/crates/core/src/redpiler/backend/mod.rs
+++ b/crates/core/src/redpiler/backend/mod.rs
@@ -4,17 +4,17 @@ pub mod direct;
 // pub mod par_direct;
 
 use super::compile_graph::CompileGraph;
-use crate::plot::PlotWorld;
+use crate::world::World;
 use mchprs_blocks::BlockPos;
 use mchprs_world::TickEntry;
 
-pub trait JITBackend {
+pub trait JITBackend<W: World> {
     fn compile(&mut self, graph: CompileGraph, ticks: Vec<TickEntry>);
-    fn tick(&mut self, plot: &mut PlotWorld);
-    fn on_use_block(&mut self, plot: &mut PlotWorld, pos: BlockPos);
-    fn set_pressure_plate(&mut self, plot: &mut PlotWorld, pos: BlockPos, powered: bool);
-    fn flush(&mut self, plot: &mut PlotWorld, io_only: bool);
-    fn reset(&mut self, plot: &mut PlotWorld, io_only: bool);
+    fn tick(&mut self, world: &mut W);
+    fn on_use_block(&mut self, world: &mut W, pos: BlockPos);
+    fn set_pressure_plate(&mut self, world: &mut W, pos: BlockPos, powered: bool);
+    fn flush(&mut self, world: &mut W, io_only: bool);
+    fn reset(&mut self, world: &mut W, io_only: bool);
     /// Inspect block for debugging
     fn inspect(&mut self, pos: BlockPos);
 }

--- a/crates/core/src/redpiler/backend/mod.rs
+++ b/crates/core/src/redpiler/backend/mod.rs
@@ -5,16 +5,35 @@ pub mod direct;
 
 use super::compile_graph::CompileGraph;
 use crate::world::World;
+use enum_dispatch::enum_dispatch;
 use mchprs_blocks::BlockPos;
 use mchprs_world::TickEntry;
 
-pub trait JITBackend<W: World> {
+#[enum_dispatch]
+pub trait JITBackend {
     fn compile(&mut self, graph: CompileGraph, ticks: Vec<TickEntry>);
-    fn tick(&mut self, world: &mut W);
-    fn on_use_block(&mut self, world: &mut W, pos: BlockPos);
-    fn set_pressure_plate(&mut self, world: &mut W, pos: BlockPos, powered: bool);
-    fn flush(&mut self, world: &mut W, io_only: bool);
-    fn reset(&mut self, world: &mut W, io_only: bool);
+    fn tick(&mut self);
+    fn on_use_block(&mut self, pos: BlockPos);
+    fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool);
+    fn flush<W: World>(&mut self, world: &mut W, io_only: bool);
+    fn reset<W: World>(&mut self, world: &mut W, io_only: bool);
     /// Inspect block for debugging
     fn inspect(&mut self, pos: BlockPos);
+}
+
+use direct::DirectBackend;
+#[cfg(feature = "jit_cranelift")]
+use cranelift::CraneliftBackend;
+
+#[enum_dispatch(JITBackend)]
+pub enum BackendDispatcher {
+    DirectBackend,
+    #[cfg(feature = "jit_cranelift")]
+    CraneliftBackend,
+}
+
+impl Default for BackendDispatcher {
+    fn default() -> Self {
+        Self::DirectBackend(Default::default())
+    }
 }

--- a/crates/core/src/redpiler/passes/clamp_weights.rs
+++ b/crates/core/src/redpiler/passes/clamp_weights.rs
@@ -1,11 +1,12 @@
 use super::Pass;
 use crate::redpiler::compile_graph::CompileGraph;
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 
 pub struct ClampWeights;
 
-impl Pass for ClampWeights {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for ClampWeights {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         graph.retain_edges(|g, edge| g[edge].ss < 15);
     }
 }

--- a/crates/core/src/redpiler/passes/coalesce.rs
+++ b/crates/core/src/redpiler/passes/coalesce.rs
@@ -1,13 +1,14 @@
 use super::Pass;
 use crate::redpiler::compile_graph::{CompileGraph, LinkType, NodeIdx, NodeType};
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 use petgraph::visit::{EdgeRef, NodeIndexable};
 use petgraph::Direction;
 
 pub struct Coalesce;
 
-impl Pass for Coalesce {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for Coalesce {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         for i in 0..graph.node_bound() {
             let idx = NodeIdx::new(i);
             if !graph.contains_node(idx) {

--- a/crates/core/src/redpiler/passes/constant_coalesce.rs
+++ b/crates/core/src/redpiler/passes/constant_coalesce.rs
@@ -1,14 +1,15 @@
 use super::Pass;
 use crate::redpiler::compile_graph::{CompileGraph, NodeIdx, NodeType};
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 use petgraph::visit::NodeIndexable;
 use petgraph::Direction;
 use std::collections::HashMap;
 
 pub struct ConstantCoalesce;
 
-impl Pass for ConstantCoalesce {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for ConstantCoalesce {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         let mut constant_nodes = HashMap::new();
 
         for i in 0..graph.node_bound() {

--- a/crates/core/src/redpiler/passes/constant_fold.rs
+++ b/crates/core/src/redpiler/passes/constant_fold.rs
@@ -2,14 +2,15 @@ use super::Pass;
 use crate::blocks::ComparatorMode;
 use crate::redpiler::compile_graph::{CompileGraph, LinkType, NodeIdx, NodeType};
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 use petgraph::visit::{EdgeRef, NodeIndexable};
 use petgraph::Direction;
 use tracing::trace;
 
 pub struct ConstantFold;
 
-impl Pass for ConstantFold {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for ConstantFold {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         loop {
             let num_folded = fold(graph);
             if num_folded == 0 {

--- a/crates/core/src/redpiler/passes/dedup_links.rs
+++ b/crates/core/src/redpiler/passes/dedup_links.rs
@@ -8,13 +8,14 @@
 use super::Pass;
 use crate::redpiler::compile_graph::{CompileGraph, NodeIdx};
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 use petgraph::visit::{EdgeRef, NodeIndexable};
 use petgraph::Direction;
 
 pub struct DedupLinks;
 
-impl Pass for DedupLinks {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for DedupLinks {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         for i in 0..graph.node_bound() {
             let idx = NodeIdx::new(i);
             if !graph.contains_node(idx) {

--- a/crates/core/src/redpiler/passes/export_graph.rs
+++ b/crates/core/src/redpiler/passes/export_graph.rs
@@ -4,6 +4,7 @@ use crate::redpiler::compile_graph::{
     CompileGraph, LinkType as CLinkType, NodeIdx, NodeType as CNodeType,
 };
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 use itertools::Itertools;
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
@@ -79,8 +80,8 @@ fn convert_node(
 
 pub struct ExportGraph;
 
-impl Pass for ExportGraph {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for ExportGraph {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         let mut nodes_map = HashMap::with_capacity(graph.node_count());
         for node in graph.node_indices() {
             nodes_map.insert(node, nodes_map.len());

--- a/crates/core/src/redpiler/passes/unreachable_output.rs
+++ b/crates/core/src/redpiler/passes/unreachable_output.rs
@@ -9,13 +9,14 @@ use super::Pass;
 use crate::blocks::ComparatorMode;
 use crate::redpiler::compile_graph::{CompileGraph, LinkType, NodeIdx, NodeType};
 use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
 use petgraph::visit::{EdgeRef, NodeIndexable};
 use petgraph::Direction;
 
 pub struct UnreachableOutput;
 
-impl Pass for UnreachableOutput {
-    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_>) {
+impl<W: World> Pass<W> for UnreachableOutput {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         for i in 0..graph.node_bound() {
             let idx = NodeIdx::new(i);
             if !graph.contains_node(idx) {


### PR DESCRIPTION
This makes Redpiler generic over the `World` trait. 

This is especially good for those wanting to use Redpiler independently from the plot system with their own world types.