### PR TITLE
Render filter optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,8 @@ dependencies = [
  "mysql",
  "once_cell",
  "petgraph",
+ "phf",
+ "phf_codegen",
  "rand",
  "redpiler_graph",
  "regex",
@@ -1776,6 +1778,58 @@ checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2293,6 +2347,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ server_context = "global"
 | `/redpiler compile` | `/rp c` | Manually starts redpiler compilation. Available flags: --io-only --optimize --export (or in short: -I -O -E) |
 | `/redpiler reset` | `/rp r` | Stops redpiler. |
 | `/toggleautorp` | None | Toggles automatic redpiler compilation. |
-| `/togglerenderfilter` | None | Toggles render filtering (Supress updating non I/O redstone components). |
+| `/toggleioonly` | None | Toggles whether to visually update non-IO redstone components. (Also forces --io-only) |
 | `/stop` | None | Stops the server. |
 
 ### Plot Ownership

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ server_context = "global"
 | `/redpiler compile` | `/rp c` | Manually starts redpiler compilation. Available flags: --io-only --optimize --export (or in short: -I -O -E) |
 | `/redpiler reset` | `/rp r` | Stops redpiler. |
 | `/toggleautorp` | None | Toggles automatic redpiler compilation. |
+| `/togglerenderfilter` | None | Toggles render filtering (Supress updating non I/O redstone components). |
 | `/stop` | None | Stops the server. |
 
 ### Plot Ownership

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,11 @@ harness = false
 name = "chungus"
 harness = false
 
+[build-dependencies]
+phf = { version = "0.11", default-features = false }
+phf_codegen = "0.11"
+mchprs_blocks = { path = "../blocks" }
+
 [dependencies]
 mchprs_proc_macros = { path = "../proc_macros" }
 toml = "0.7"
@@ -46,6 +51,7 @@ once_cell = "1.14.0"
 smallvec = "1.9.0"
 petgraph = "0.6"
 rustc-hash = "1.1"
+phf = { version = "0.11", features = ["macros"] }
 redpiler_graph = { path = "../redpiler_graph" }
 mchprs_save_data = { path = "../save_data" }
 mchprs_blocks = { path = "../blocks" }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -3,14 +3,14 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use mchprs_blocks::blocks::{Block, RedstoneWireSide};
+use mchprs_blocks::blocks::Block;
 
 /// This build script generates a perfect hash set to filter out any unnecessary block changes.
 /// Best used for big redstone screens as it eases the load on the mincraft client's chunk rendering threads, resulting in visually faster updates.
-/// Toggle the filter with //togglerf
+/// Toggle the filter with //toggleioonly
 /// Warning: Filtering will cause redstone components to look like they aren't updating. This persists until the affected blocks are changed again or the chunk is reloaded
 fn main() {
-    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("block_filter.rs");
+    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("io_only_filter.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 
     let mut set = phf_codegen::Set::<u32>::new();
@@ -20,11 +20,6 @@ fn main() {
         let block = Block::from_id(id);
 
         match block {
-            //Block::RedstoneWire { wire }
-            //if wire.north == RedstoneWireSide::None
-            //    && wire.east == RedstoneWireSide::None
-            //    && wire.south == RedstoneWireSide::None
-            //    && wire.west == RedstoneWireSide::None => {}
             Block::RedstoneWire { .. }
             | Block::RedstoneTorch { .. }
             | Block::RedstoneWallTorch { .. }
@@ -41,7 +36,7 @@ fn main() {
     }
     write!(
         &mut file,
-        "static RENDER_FILTER_BLACKLIST: phf::Set<u32> = {};\n",
+        "static IO_ONLY_BLACKLIST: phf::Set<u32> = {};\n",
         set.build()
     )
     .unwrap();

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,0 +1,43 @@
+use std::env;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use mchprs_blocks::blocks::{Block, RedstoneWireSide};
+
+/// This build script generates a perfect hash set to filter out any unnecessary block changes.
+/// Best used for big redstone screens as it eases the load on the mincraft client's chunk rendering threads, resulting in visually faster updates.
+/// Toggle the filter with //togglerf
+/// Warning: Filtering will cause redstone components to look like they aren't updating. This persists until the affected blocks's chunk is reloaded
+fn main() {
+    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("block_filter.rs");
+    let mut file = BufWriter::new(File::create(&path).unwrap());
+
+    let mut set = phf_codegen::Set::<u32>::new();
+
+    // Magic number, not sure how many total block states there are, but 2^16 should hopefully be enough
+    for id in 0..65536 {
+        let block = Block::from_id(id);
+
+        match block {
+            Block::RedstoneWire { .. }
+            | Block::RedstoneTorch { .. }
+            | Block::RedstoneWallTorch { .. }
+            | Block::RedstoneRepeater { .. }
+            //| Block::RedstoneLamp { .. }
+            | Block::RedstoneComparator { .. }
+            | Block::Observer { .. }
+            //| Block::IronTrapdoor { .. }
+            => {
+                set.entry(id);
+            }
+            _ => {}
+        }
+    }
+    write!(
+        &mut file,
+        "static RENDER_FILTER_BLACKLIST: phf::Set<u32> = {};\n",
+        set.build()
+    )
+    .unwrap();
+}

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -8,7 +8,7 @@ use mchprs_blocks::blocks::{Block, RedstoneWireSide};
 /// This build script generates a perfect hash set to filter out any unnecessary block changes.
 /// Best used for big redstone screens as it eases the load on the mincraft client's chunk rendering threads, resulting in visually faster updates.
 /// Toggle the filter with //togglerf
-/// Warning: Filtering will cause redstone components to look like they aren't updating. This persists until the affected blocks's chunk is reloaded
+/// Warning: Filtering will cause redstone components to look like they aren't updating. This persists until the affected blocks are changed again or the chunk is reloaded
 fn main() {
     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("block_filter.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
@@ -20,6 +20,11 @@ fn main() {
         let block = Block::from_id(id);
 
         match block {
+            //Block::RedstoneWire { wire }
+            //if wire.north == RedstoneWireSide::None
+            //    && wire.east == RedstoneWireSide::None
+            //    && wire.south == RedstoneWireSide::None
+            //    && wire.west == RedstoneWireSide::None => {}
             Block::RedstoneWire { .. }
             | Block::RedstoneTorch { .. }
             | Block::RedstoneWallTorch { .. }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -19,17 +19,17 @@ fn main() {
     for id in 0..65536 {
         let block = Block::from_id(id);
 
-        // Matches all blocks that should be considered as ouput components
+        // Matches all blocks that should be considered as input components
         match block {
-            Block::RedstoneLamp { .. } | Block::IronTrapdoor { .. } => {
+            Block::Lever { .. } | Block::StoneButton { .. } | Block::StonePressurePlate { .. } => {
                 input_set.entry(id);
             }
             _ => {}
         }
 
-        // Matches all blocks that should be considered as ouput components
+        // Matches all blocks that should be considered as output components
         match block {
-            Block::Lever { .. } | Block::StoneButton { .. } | Block::StonePressurePlate { .. } => {
+            Block::RedstoneLamp { .. } | Block::IronTrapdoor { .. } => {
                 output_set.entry(id);
             }
             _ => {}

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -496,6 +496,7 @@ impl Plot {
                 if self.render_filter {
                     self.players[player].send_system_message("Render filtering has been enabled.");
                 } else {
+                    // TODO: Resend all skipped block changes
                     self.players[player].send_system_message("Render filtering has been disabled.");
                 }
             }
@@ -528,7 +529,7 @@ pub static DECLARE_COMMANDS: Lazy<PacketEncoder> = Lazy::new(|| {
                 flags: CommandFlags::ROOT.bits() as i8,
                 children: &[
                     1, 4, 5, 6, 11, 12, 14, 16, 18, 19, 20, 21, 22, 23, 24, 26, 29, 31, 32, 34, 36,
-                    47, 49, 53, 60, 61, 63,
+                    47, 49, 53, 60, 61, 63, 65, 66, 67, 68, 72,
                 ],
                 redirect_node: None,
                 name: None,
@@ -1113,6 +1114,78 @@ pub static DECLARE_COMMANDS: Lazy<PacketEncoder> = Lazy::new(|| {
                 name: Some("filename"),
                 parser: Some(Parser::String(0)),
                 suggestions_type: Some("minecraft:ask_server"),
+            },
+            // 65: /togglerenderfilter
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("togglerenderfilter"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 66: /togglerf
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::REDIRECT).bits() as i8,
+                children: &[],
+                redirect_node: Some(65),
+                name: Some("togglerf"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 67: /redpiler
+            Node {
+                flags: CommandFlags::LITERAL.bits() as i8,
+                children: &[69, 70, 71], // Children are compile, inspect, reset
+                redirect_node: None,
+                name: Some("redpiler"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 68: /rp
+            Node {
+                flags: (CommandFlags::REDIRECT | CommandFlags::LITERAL).bits() as i8,
+                children: &[],
+                redirect_node: Some(67), // Redirect to /redpiler
+                name: Some("rp"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 69: /redpiler compile
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("compile"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 70: /redpiler inspect
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("inspect"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 71: /redpiler reset
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("reset"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 72: /toggleautorp
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("toggleautorp"),
+                parser: None,
+                suggestions_type: None,
             },
         ],
         root_index: 0,

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -182,7 +182,9 @@ impl Plot {
                 }
                 if self.io_only_mode {
                     options.io_only = true;
-                    self.players[player].send_system_message("Forcing --io-only flag, because io-only mode is active.");
+                    self.players[player].send_system_message(
+                        "Forcing --io-only flag, because io-only mode is active.",
+                    );
                 }
 
                 self.reset_redpiler();

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -491,6 +491,14 @@ impl Plot {
                 let slot = 36 + self.players[player].selected_slot;
                 self.players[player].set_inventory_slot(slot, Some(item));
             }
+            "/togglerenderfilter" | "/togglerf" => {
+                self.render_filter = !self.render_filter;
+                if self.render_filter {
+                    self.players[player].send_system_message("Render filtering has been enabled.");
+                } else {
+                    self.players[player].send_system_message("Render filtering has been disabled.");
+                }
+            }
             _ => self.players[player].send_error_message("Command not found!"),
         }
         false

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -51,8 +51,8 @@ pub const NUM_CHUNKS: usize = PLOT_WIDTH.pow(2) as usize;
 
 pub const WORLD_SEND_RATE: Duration = Duration::from_millis(15);
 
-// Include perfect hash set `RENDER_FILTER_BLACKLIST`
-include!(concat!(env!("OUT_DIR"), "/block_filter.rs"));
+// Include perfect hash set `IO_ONLY_BLACKLIST`
+include!(concat!(env!("OUT_DIR"), "/io_only_filter.rs"));
 
 pub struct Plot {
     pub world: PlotWorld,
@@ -84,7 +84,7 @@ pub struct Plot {
     /// If true, the plot will remain running even if no players are on for a long time.
     always_running: bool,
     auto_redpiler: bool,
-    render_filter: bool,
+    io_only_mode: bool,
 
     owner: Option<u128>,
     async_rt: Runtime,
@@ -115,12 +115,12 @@ impl PlotWorld {
         Some(((chunk_x << PLOT_SCALE) + chunk_z).unsigned_abs() as usize)
     }
 
-    fn flush_block_changes(&mut self, render_filter: bool) {
+    fn flush_block_changes(&mut self, io_only_mode: bool) {
         for packet in self.chunks.iter_mut().flat_map(|c| c.multi_blocks()) {
-            if render_filter {
+            if io_only_mode {
                 packet
                     .records
-                    .retain(|r| !RENDER_FILTER_BLACKLIST.contains(&r.block_id));
+                    .retain(|r| !IO_ONLY_BLACKLIST.contains(&r.block_id));
                 if packet.records.is_empty() {
                     continue;
                 }
@@ -900,7 +900,7 @@ impl Plot {
             let time_since_last_world_send = now - self.last_world_send_time;
             if time_since_last_world_send > WORLD_SEND_RATE {
                 self.last_world_send_time = now;
-                self.world.flush_block_changes(self.render_filter);
+                self.world.flush_block_changes(self.io_only_mode);
             }
         } else {
             self.timings.set_ticking(false);
@@ -1000,7 +1000,7 @@ impl Plot {
             auto_redpiler: CONFIG.auto_redpiler,
             tps,
             always_running,
-            render_filter: false,
+            io_only_mode: false,
             redpiler: Default::default(),
             timings: TimingsMonitor::new(tps),
             owner: database::get_plot_owner(x, z).map(|s| s.parse::<HyphenatedUUID>().unwrap().0),

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -51,8 +51,8 @@ pub const NUM_CHUNKS: usize = PLOT_WIDTH.pow(2) as usize;
 
 pub const WORLD_SEND_RATE: Duration = Duration::from_millis(15);
 
-// Include perfect hash set `IO_ONLY_BLACKLIST`
-include!(concat!(env!("OUT_DIR"), "/io_only_filter.rs"));
+// Include perfect hash sets for blocks
+include!(concat!(env!("OUT_DIR"), "/block_filters.rs"));
 
 pub struct Plot {
     pub world: PlotWorld,
@@ -118,9 +118,11 @@ impl PlotWorld {
     fn flush_block_changes(&mut self, io_only_mode: bool) {
         for packet in self.chunks.iter_mut().flat_map(|c| c.multi_blocks()) {
             if io_only_mode {
-                packet
-                    .records
-                    .retain(|r| !IO_ONLY_BLACKLIST.contains(&r.block_id));
+                packet.records.retain(|r| {
+                    !CHANGING_BLOCKS.contains(&r.block_id)
+                        || INPUT_BLOCKS.contains(&r.block_id)
+                        || OUTPUT_BLOCKS.contains(&r.block_id)
+                });
                 if packet.records.is_empty() {
                     continue;
                 }

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -51,6 +51,9 @@ pub const NUM_CHUNKS: usize = PLOT_WIDTH.pow(2) as usize;
 
 pub const WORLD_SEND_RATE: Duration = Duration::from_millis(15);
 
+// Include perfect hash set `RENDER_FILTER_BLACKLIST`
+include!(concat!(env!("OUT_DIR"), "/block_filter.rs"));
+
 pub struct Plot {
     pub world: PlotWorld,
     pub players: Vec<Player>,
@@ -81,6 +84,7 @@ pub struct Plot {
     /// If true, the plot will remain running even if no players are on for a long time.
     always_running: bool,
     auto_redpiler: bool,
+    render_filter: bool,
 
     owner: Option<u128>,
     async_rt: Runtime,
@@ -111,15 +115,22 @@ impl PlotWorld {
         Some(((chunk_x << PLOT_SCALE) + chunk_z).unsigned_abs() as usize)
     }
 
-    fn flush_block_changes(&mut self) {
+    fn flush_block_changes(&mut self, render_filter: bool) {
         for packet in self.chunks.iter_mut().flat_map(|c| c.multi_blocks()) {
+            if render_filter {
+                packet
+                    .records
+                    .retain(|r| !RENDER_FILTER_BLACKLIST.contains(&r.block_id));
+                if packet.records.is_empty() {
+                    continue;
+                }
+            }
+
             let encoded = packet.encode();
             for player in &self.packet_senders {
                 player.send_packet(&encoded);
             }
-        }
-        for chunk in &mut self.chunks {
-            chunk.reset_multi_blocks();
+            packet.records.clear();
         }
     }
 
@@ -889,7 +900,7 @@ impl Plot {
             let time_since_last_world_send = now - self.last_world_send_time;
             if time_since_last_world_send > WORLD_SEND_RATE {
                 self.last_world_send_time = now;
-                self.world.flush_block_changes();
+                self.world.flush_block_changes(self.render_filter);
             }
         } else {
             self.timings.set_ticking(false);
@@ -989,6 +1000,7 @@ impl Plot {
             auto_redpiler: CONFIG.auto_redpiler,
             tps,
             always_running,
+            render_filter: false,
             redpiler: Default::default(),
             timings: TimingsMonitor::new(tps),
             owner: database::get_plot_owner(x, z).map(|s| s.parse::<HyphenatedUUID>().unwrap().0),

--- a/crates/core/src/plot/packet_handlers.rs
+++ b/crates/core/src/plot/packet_handlers.rs
@@ -255,7 +255,7 @@ impl ServerBoundPacketHandler for Plot {
             if cancelled {
                 cancel(self);
             }
-            self.world.flush_block_changes();
+            self.world.flush_block_changes(false);
             return;
         }
 
@@ -268,7 +268,7 @@ impl ServerBoundPacketHandler for Plot {
                 block_pos,
                 None,
             );
-            self.world.flush_block_changes();
+            self.world.flush_block_changes(false);
         }
     }
 
@@ -497,7 +497,7 @@ impl ServerBoundPacketHandler for Plot {
             self.reset_redpiler();
 
             interaction::destroy(block, &mut self.world, block_pos);
-            self.world.flush_block_changes();
+            self.world.flush_block_changes(false);
 
             let effect = CEffect {
                 effect_id: 2001,

--- a/crates/core/src/plot/worldedit/mod.rs
+++ b/crates/core/src/plot/worldedit/mod.rs
@@ -1061,7 +1061,7 @@ fn paste_clipboard(plot: &mut PlotWorld, cb: &WorldEditClipboard, pos: BlockPos,
     }
 
     // Send block changes before we send block entity data, otherwise it'll be ignored
-    plot.flush_block_changes();
+    plot.flush_block_changes(false);
 
     for (pos, block_entity) in &cb.block_entities {
         let new_pos = BlockPos {

--- a/crates/core/src/redpiler/compile_graph.rs
+++ b/crates/core/src/redpiler/compile_graph.rs
@@ -18,12 +18,6 @@ pub enum NodeType {
     Constant,
 }
 
-impl NodeType {
-    pub fn is_output(self) -> bool {
-        matches!(self, NodeType::Lamp | NodeType::Trapdoor)
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct NodeState {
     pub powered: bool,

--- a/crates/core/src/redpiler/compile_graph.rs
+++ b/crates/core/src/redpiler/compile_graph.rs
@@ -72,6 +72,8 @@ pub struct CompileNode {
 
     pub facing_diode: bool,
     pub comparator_far_input: Option<u8>,
+    pub is_input: bool,
+    pub is_output: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/redpiler/passes/coalesce.rs
+++ b/crates/core/src/redpiler/passes/coalesce.rs
@@ -18,7 +18,7 @@ impl<W: World> Pass<W> for Coalesce {
             let node = &graph[idx];
             // Comparators depend on the link weight as well as the type,
             // we could implement that later if it's beneficial enough.
-            if matches!(node.ty, NodeType::Comparator(_)) || node.ty.is_output() {
+            if matches!(node.ty, NodeType::Comparator(_)) || node.is_output {
                 continue;
             }
 

--- a/crates/core/src/redpiler/passes/identify_nodes.rs
+++ b/crates/core/src/redpiler/passes/identify_nodes.rs
@@ -82,6 +82,8 @@ fn for_pos<W: World>(ignore_wires: bool, world: &W, graph: &mut CompileGraph, po
 
         facing_diode,
         comparator_far_input: None,
+        is_input: crate::plot::INPUT_BLOCKS.contains(&id),
+        is_output: crate::plot::OUTPUT_BLOCKS.contains(&id),
     });
 }
 

--- a/crates/core/src/world/storage.rs
+++ b/crates/core/src/world/storage.rs
@@ -362,7 +362,7 @@ impl ChunkSection {
         }
     }
 
-    fn multi_block(&mut self, chunk_x: i32, chunk_y: u32, chunk_z: i32) -> &CMultiBlockChange {
+    fn multi_block(&mut self, chunk_x: i32, chunk_y: u32, chunk_z: i32) -> &mut CMultiBlockChange {
         self.multi_block.chunk_x = chunk_x;
         self.multi_block.chunk_y = chunk_y;
         self.multi_block.chunk_z = chunk_z;
@@ -381,7 +381,7 @@ impl ChunkSection {
             self.changed = false;
             self.changed_blocks = [-1; 16 * 16 * 16];
         }
-        &self.multi_block
+        &mut self.multi_block
     }
 }
 
@@ -561,7 +561,7 @@ impl Chunk {
         }
     }
 
-    pub fn multi_blocks(&mut self) -> impl Iterator<Item = &CMultiBlockChange> {
+    pub fn multi_blocks(&mut self) -> impl Iterator<Item = &mut CMultiBlockChange> {
         let x = self.x;
         let z = self.z;
         self.sections
@@ -572,11 +572,5 @@ impl Chunk {
                     .changed
                     .then(move || section.multi_block(x, y as u32, z))
             })
-    }
-
-    pub fn reset_multi_blocks(&mut self) {
-        for section in &mut self.sections {
-            section.multi_block.records.clear();
-        }
     }
 }


### PR DESCRIPTION
Adds a command `/togglerenderfilter` to toggle the render filter optimization (per plot).
This stops the server from sending non-IO redstone component block changes to the client.
This commit also adds a few more commands to the auto complete graph.

Considerations:
- After deactivating the filter all affected redstone components are still in a desynchronized state. Maybe invert the filter and resend all "missed" changes
- Using a build script and perfect hash functions may be a bit overkill and add unnecessary code complexity (Move to different/separate crate?)
- This setting could make more sense as an per player option, this could possibly be a bit trickier to implement