### PR TITLE
Replace default std hasher with rustc-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "rustc-hash",
  "serde",
  "serde_json",
  "smallvec",
@@ -1414,6 +1415,7 @@ dependencies = [
  "byteorder",
  "mchprs_blocks",
  "mchprs_world",
+ "rustc-hash",
  "serde",
  "thiserror",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,6 +45,7 @@ bincode = "1.3"
 once_cell = "1.14.0"
 smallvec = "1.9.0"
 petgraph = "0.6"
+rustc-hash = "1.1"
 redpiler_graph = { path = "../redpiler_graph" }
 mchprs_save_data = { path = "../save_data" }
 mchprs_blocks = { path = "../blocks" }

--- a/crates/core/src/plot/worldedit/mod.rs
+++ b/crates/core/src/plot/worldedit/mod.rs
@@ -15,6 +15,7 @@ use mchprs_utils::map;
 use once_cell::sync::Lazy;
 use rand::Rng;
 use regex::Regex;
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -765,7 +766,7 @@ pub struct WorldEditClipboard {
     pub size_y: u32,
     pub size_z: u32,
     pub data: PalettedBitBuffer,
-    pub block_entities: HashMap<BlockPos, BlockEntity>,
+    pub block_entities: FxHashMap<BlockPos, BlockEntity>,
 }
 
 #[derive(Clone, Debug)]
@@ -985,7 +986,7 @@ fn create_clipboard(
         size_y,
         size_z,
         data: PalettedBitBuffer::new((size_x * size_y * size_z) as usize, 9),
-        block_entities: HashMap::new(),
+        block_entities: FxHashMap::default(),
     };
     let mut i = 0;
     for y in start_pos.y..=end_pos.y {

--- a/crates/core/src/plot/worldedit/schematic.rs
+++ b/crates/core/src/plot/worldedit/schematic.rs
@@ -11,8 +11,8 @@ use mchprs_blocks::blocks::Block;
 use mchprs_blocks::BlockPos;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::PathBuf;
 
@@ -56,7 +56,7 @@ pub fn load_schematic(file_name: &str) -> Result<WorldEditClipboard> {
     let offset_x = -nbt_as!(metadata["WEOffsetX"], Value::Int);
     let offset_y = -nbt_as!(metadata["WEOffsetY"], Value::Int);
     let offset_z = -nbt_as!(metadata["WEOffsetZ"], Value::Int);
-    let mut palette: HashMap<u32, u32> = HashMap::new();
+    let mut palette: FxHashMap<u32, u32> = FxHashMap::default();
     for (k, v) in nbt_palette {
         let id = *nbt_as!(v, Value::Int) as u32;
         let block = parse_block(k).with_context(|| format!("error parsing block: {}", k))?;
@@ -87,7 +87,7 @@ pub fn load_schematic(file_name: &str) -> Result<WorldEditClipboard> {
         }
     }
     let block_entities = nbt_as!(&nbt["BlockEntities"], Value::List);
-    let mut parsed_block_entities = HashMap::new();
+    let mut parsed_block_entities = FxHashMap::default();
     for block_entity in block_entities {
         let val = nbt_as!(block_entity, Value::Compound);
         let pos_array = nbt_as!(&val["Pos"], Value::IntArray);

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -11,8 +11,8 @@ use mchprs_world::{TickEntry, TickPriority};
 use nodes::{NodeId, Nodes};
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
-use std::collections::HashMap;
 use std::{fmt, mem};
 use tracing::{debug, trace, warn};
 
@@ -152,7 +152,7 @@ impl Node {
         graph: &CompileGraph,
         node_idx: NodeIdx,
         nodes_len: usize,
-        nodes_map: &HashMap<NodeIdx, usize>,
+        nodes_map: &FxHashMap<NodeIdx, usize>,
         stats: &mut FinalGraphStats,
     ) -> Self {
         let node = &graph[node_idx];
@@ -308,7 +308,7 @@ impl TickScheduler {
 pub struct DirectBackend {
     nodes: Nodes,
     blocks: Vec<Option<(BlockPos, Block)>>,
-    pos_map: HashMap<BlockPos, NodeId>,
+    pos_map: FxHashMap<BlockPos, NodeId>,
     scheduler: TickScheduler,
 }
 
@@ -482,7 +482,8 @@ impl JITBackend for DirectBackend {
     }
 
     fn compile(&mut self, graph: CompileGraph, ticks: Vec<TickEntry>) {
-        let mut nodes_map = HashMap::with_capacity(graph.node_count());
+        let mut nodes_map =
+            FxHashMap::with_capacity_and_hasher(graph.node_count(), Default::default());
         for node in graph.node_indices() {
             nodes_map.insert(node, nodes_map.len());
         }

--- a/crates/core/src/redpiler/passes/constant_coalesce.rs
+++ b/crates/core/src/redpiler/passes/constant_coalesce.rs
@@ -4,13 +4,13 @@ use crate::redpiler::{CompilerInput, CompilerOptions};
 use crate::world::World;
 use petgraph::visit::NodeIndexable;
 use petgraph::Direction;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 pub struct ConstantCoalesce;
 
 impl<W: World> Pass<W> for ConstantCoalesce {
     fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
-        let mut constant_nodes = HashMap::new();
+        let mut constant_nodes = FxHashMap::default();
 
         for i in 0..graph.node_bound() {
             let idx = NodeIdx::new(i);

--- a/crates/core/src/redpiler/passes/export_graph.rs
+++ b/crates/core/src/redpiler/passes/export_graph.rs
@@ -11,13 +11,13 @@ use petgraph::Direction;
 use redpiler_graph::{
     serialize, BlockPos, ComparatorMode, Link, LinkType, Node, NodeState, NodeType,
 };
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs;
 
 fn convert_node(
     graph: &CompileGraph,
     node_idx: NodeIdx,
-    nodes_map: &HashMap<NodeIdx, usize>,
+    nodes_map: &FxHashMap<NodeIdx, usize>,
 ) -> Node {
     let node = &graph[node_idx];
 
@@ -82,7 +82,8 @@ pub struct ExportGraph;
 
 impl<W: World> Pass<W> for ExportGraph {
     fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
-        let mut nodes_map = HashMap::with_capacity(graph.node_count());
+        let mut nodes_map =
+            FxHashMap::with_capacity_and_hasher(graph.node_count(), Default::default());
         for node in graph.node_indices() {
             nodes_map.insert(node, nodes_map.len());
         }

--- a/crates/core/src/redpiler/passes/input_search.rs
+++ b/crates/core/src/redpiler/passes/input_search.rs
@@ -11,7 +11,8 @@ use crate::world::World;
 use mchprs_blocks::blocks::{Block, ButtonFace, LeverFace};
 use mchprs_blocks::{BlockDirection, BlockFace, BlockPos};
 use petgraph::visit::NodeIndexable;
-use std::collections::{HashMap, VecDeque};
+use rustc_hash::FxHashMap;
+use std::collections::VecDeque;
 
 pub struct InputSearch;
 
@@ -35,12 +36,12 @@ impl<W: World> Pass<W> for InputSearch {
 struct InputSearchState<'a, W: World> {
     world: &'a W,
     graph: &'a mut CompileGraph,
-    pos_map: HashMap<BlockPos, NodeIdx>,
+    pos_map: FxHashMap<BlockPos, NodeIdx>,
 }
 
 impl<'a, W: World> InputSearchState<'a, W> {
     fn new(world: &'a W, graph: &'a mut CompileGraph) -> InputSearchState<'a, W> {
-        let mut pos_map = HashMap::new();
+        let mut pos_map = FxHashMap::default();
         for id in graph.node_indices() {
             let (pos, _) = graph[id].block.unwrap();
             pos_map.insert(pos, id);
@@ -174,7 +175,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
         mut distance: u8,
     ) {
         let mut queue: VecDeque<BlockPos> = VecDeque::new();
-        let mut discovered = HashMap::new();
+        let mut discovered = FxHashMap::default();
 
         discovered.insert(root_pos, distance);
         queue.push_back(root_pos);

--- a/crates/core/src/redstone/wire/turbo.rs
+++ b/crates/core/src/redstone/wire/turbo.rs
@@ -6,7 +6,7 @@ use crate::redstone;
 use crate::world::World;
 use mchprs_blocks::blocks::{Block, RedstoneWire};
 use mchprs_blocks::{BlockFace, BlockPos};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 fn unwrap_wire(block: Block) -> RedstoneWire {
     match block {
@@ -55,7 +55,7 @@ impl UpdateNode {
 
 pub(super) struct RedstoneWireTurbo {
     nodes: Vec<UpdateNode>,
-    node_cache: HashMap<BlockPos, NodeId>,
+    node_cache: FxHashMap<BlockPos, NodeId>,
     update_queue: Vec<Vec<NodeId>>,
     current_walk_layer: u32,
 }
@@ -70,7 +70,7 @@ impl RedstoneWireTurbo {
     fn new() -> RedstoneWireTurbo {
         RedstoneWireTurbo {
             nodes: Vec::new(),
-            node_cache: HashMap::new(),
+            node_cache: FxHashMap::default(),
             update_queue: vec![vec![], vec![], vec![]],
             current_walk_layer: 0,
         }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -20,9 +20,9 @@ use mchprs_network::packets::serverbound::{
 use mchprs_network::packets::{PacketEncoderExt, SlotData};
 use mchprs_network::{NetworkServer, NetworkState, PlayerPacketSender};
 use mchprs_utils::map;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
 use std::fs::{self, File};
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -122,7 +122,7 @@ pub struct MinecraftServer {
     broadcaster: Bus<BroadcastMessage>,
     receiver: Receiver<Message>,
     plot_sender: Sender<Message>,
-    online_players: HashMap<u128, PlayerListEntry>,
+    online_players: FxHashMap<u128, PlayerListEntry>,
     running_plots: Vec<PlotListEntry>,
     whitelist: Option<Vec<WhitelistEntry>>,
 }
@@ -177,7 +177,7 @@ impl MinecraftServer {
             broadcaster: bus,
             receiver: server_rx,
             plot_sender: plot_tx,
-            online_players: HashMap::new(),
+            online_players: FxHashMap::default(),
             running_plots: Vec::new(),
             whitelist,
         };

--- a/crates/core/src/world/storage.rs
+++ b/crates/core/src/world/storage.rs
@@ -8,7 +8,7 @@ use mchprs_network::packets::clientbound::{
     CMultiBlockChange, ClientBoundPacket,
 };
 use mchprs_network::packets::{PacketEncoder, PalettedContainer};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::convert::TryInto;
 use std::mem;
 
@@ -406,7 +406,7 @@ pub struct Chunk {
     pub sections: [ChunkSection; 16],
     pub x: i32,
     pub z: i32,
-    pub block_entities: HashMap<BlockPos, BlockEntity>,
+    pub block_entities: FxHashMap<BlockPos, BlockEntity>,
 }
 
 impl Chunk {
@@ -557,7 +557,7 @@ impl Chunk {
             sections: Default::default(),
             x,
             z,
-            block_entities: HashMap::new(),
+            block_entities: FxHashMap::default(),
         }
     }
 

--- a/crates/save_data/Cargo.toml
+++ b/crates/save_data/Cargo.toml
@@ -10,5 +10,6 @@ byteorder = "1.4"
 bincode = "1.3"
 serde = "1"
 thiserror = "1"
+rustc-hash = "1.1"
 mchprs_world = { path = "../world" }
 mchprs_blocks = { path = "../blocks" }

--- a/crates/save_data/src/plot_data.rs
+++ b/crates/save_data/src/plot_data.rs
@@ -5,8 +5,8 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use mchprs_blocks::block_entities::BlockEntity;
 use mchprs_blocks::BlockPos;
 use mchprs_world::TickEntry;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -65,7 +65,7 @@ pub struct ChunkSectionData {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChunkData {
     pub sections: [Option<ChunkSectionData>; 16],
-    pub block_entities: HashMap<BlockPos, BlockEntity>,
+    pub block_entities: FxHashMap<BlockPos, BlockEntity>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/save_data/src/plot_data/fixer/pre_header.rs
+++ b/crates/save_data/src/plot_data/fixer/pre_header.rs
@@ -6,13 +6,14 @@ use crate::plot_data::{ChunkData, ChunkSectionData, PlotData, Tps};
 use mchprs_blocks::block_entities::BlockEntity;
 use mchprs_blocks::BlockPos;
 use mchprs_world::TickEntry;
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 #[derive(Deserialize)]
 pub struct PreHeaderChunkData {
     sections: BTreeMap<u8, ChunkSectionData>,
-    block_entities: HashMap<BlockPos, BlockEntity>,
+    block_entities: FxHashMap<BlockPos, BlockEntity>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
The default `std` HashMap/HashSet uses a cryptograpthic hash function (SipHash), this is definitely overkill. Since we don't need to protect against Hash DoS we can just use the same hash function that the rust compiler internally uses. The lower hash quality, and therefore resulting higher collision count, are offset by the drastically faster hashing algorithm.

I would have liked to replace all instances of HashMap, but that would mean also changing the nbt crate. Maybe a possible future enhancement. Anyways, the most important use cases are covered by this commit.