### PR TITLE
Duplicate signal strength to all outputs

### DIFF
--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -601,14 +601,14 @@ fn schedule_tick(
     scheduler.schedule_tick(node_id, delay, priority);
 }
 
-const INPUT_MASK: u128 = u128::from_ne_bytes([0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
+const BOOL_INPUT_MASK: u128 = u128::from_ne_bytes([0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
 
 fn get_bool_input(node: &Node) -> bool {
-    u128::from_ne_bytes(node.default_inputs) & INPUT_MASK != 0
+    u128::from_ne_bytes(node.default_inputs) & BOOL_INPUT_MASK != 0
 }
 
 fn get_bool_side(node: &Node) -> bool {
-    u128::from_ne_bytes(node.side_inputs) & INPUT_MASK != 0
+    u128::from_ne_bytes(node.side_inputs) & BOOL_INPUT_MASK != 0
 }
 
 fn last_index_positive(array: &[u8; 16]) -> u32 {

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -183,6 +183,11 @@ impl Node {
         stats: &mut FinalGraphStats,
     ) -> Self {
         let node = &graph[node_idx];
+        
+        const MAX_INPUTS: usize = 255;
+        
+        let mut default_input_count = 0;
+        let mut side_input_count = 0;
 
         let mut default_inputs = [0; 16];
         let mut side_inputs = [0; 16];
@@ -192,8 +197,20 @@ impl Node {
             let source = edge.source();
             let ss = graph[source].state.output_strength.saturating_sub(distance);
             match weight.ty {
-                LinkType::Default => default_inputs[ss as usize] += 1,
-                LinkType::Side => side_inputs[ss as usize] += 1,
+                LinkType::Default => {
+                    if default_input_count >= MAX_INPUTS {
+                        panic!("Exceeded the maximum number of default inputs {}", MAX_INPUTS);
+                    }
+                    default_input_count += 1;
+                    default_inputs[ss as usize] += 1;
+                },
+                LinkType::Side => {
+                    if side_input_count >= MAX_INPUTS {
+                        panic!("Exceeded the maximum number of side inputs {}", MAX_INPUTS);
+                    }
+                    side_input_count += 1;
+                    side_inputs[ss as usize] += 1;
+                }
             }
         }
         stats.default_link_count += default_inputs.len();

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -206,7 +206,6 @@ impl Node {
         } else {
             SmallVec::new()
         };
-        *stats.update_groups.entry(updates.len()).or_insert(0) += 1;
         stats.update_link_count += updates.len();
 
         let ty = match node.ty {

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -259,12 +259,13 @@ impl Queues {
 
 #[derive(Default)]
 struct TickScheduler {
-    queues_deque: [Queues; 16],
+    queues_deque: [Queues; Self::NUM_QUEUES],
     pos: usize,
 }
 
 impl TickScheduler {
     const NUM_PRIORITIES: usize = 4;
+    const NUM_QUEUES: usize = 16;
 
     fn reset<W: World>(&mut self, world: &mut W, blocks: &[Option<(BlockPos, Block)>]) {
         for (idx, queues) in self.queues_deque.iter().enumerate() {
@@ -287,11 +288,11 @@ impl TickScheduler {
     }
 
     fn schedule_tick(&mut self, node: NodeId, delay: usize, priority: TickPriority) {
-        self.queues_deque[(self.pos + delay) & 15].0[Self::priority_index(priority)].push(node);
+        self.queues_deque[(self.pos + delay) % Self::NUM_QUEUES].0[Self::priority_index(priority)].push(node);
     }
 
     fn queues_this_tick(&mut self) -> Queues {
-        self.pos = (self.pos + 1) & 15;
+        self.pos = (self.pos + 1) % Self::NUM_QUEUES;
         mem::take(&mut self.queues_deque[self.pos])
     }
 

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -606,7 +606,8 @@ fn get_bool_input(node: &Node) -> bool {
 }
 
 fn last_index_positive(array: &[u8; 16]) -> u32 {
-    let value = u128::from_ne_bytes(*array);
+    // Note: this might be slower on big-endian systems
+    let value = u128::from_le_bytes(*array);
     if value == 0 {0} else {15 - (value.leading_zeros() >> 3)}
 }
 

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -387,8 +387,15 @@ impl DirectBackend {
             } else {
                 &mut update_ref.default_inputs
             };
-            inputs[old_power.saturating_sub(distance) as usize] -= 1;
-            inputs[new_power.saturating_sub(distance) as usize] += 1;
+ 
+            let old_power = old_power.saturating_sub(distance);
+            let new_power = new_power.saturating_sub(distance);
+
+            // Safety: signal strength is never larger than 15
+            unsafe {
+                *inputs.get_unchecked_mut(old_power as usize) -= 1;   
+                *inputs.get_unchecked_mut(new_power as usize) += 1;
+            }
 
             update_node(&mut self.scheduler, &mut self.nodes, update);
         }

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -93,7 +93,7 @@ mod nodes {
 
 #[derive(Debug, Clone, Copy)]
 struct ForwardLink {
-    data: u32
+    data: u32,
 }
 impl ForwardLink {
     pub fn new(id: NodeId, side: bool, mut ss: u8) -> Self {
@@ -101,7 +101,9 @@ impl ForwardLink {
         if ss >= 16 {
             ss = 15;
         }
-        Self { data:  (id.index() as u32) << 5 | if side {1 << 4} else {0} | ss as u32}
+        Self {
+            data: (id.index() as u32) << 5 | if side { 1 << 4 } else { 0 } | ss as u32,
+        }
     }
     pub fn node(self) -> NodeId {
         unsafe {
@@ -155,7 +157,7 @@ pub struct Node {
     default_inputs: [u8; 16],
     side_inputs: [u8; 16],
     updates: SmallVec<[ForwardLink; 18]>,
-    
+
     facing_diode: bool,
     comparator_far_input: Option<u8>,
 
@@ -203,7 +205,7 @@ impl Node {
                     assert!(idx < nodes_len);
                     // Safety: bounds checked
                     let target_id = NodeId::from_index(idx);
-                    
+
                     let weight = edge.weight();
                     ForwardLink::new(target_id, weight.ty == LinkType::Side, weight.ss)
                 })
@@ -271,7 +273,11 @@ impl TickScheduler {
 
     fn reset<W: World>(&mut self, world: &mut W, blocks: &[Option<(BlockPos, Block)>]) {
         for (idx, queues) in self.queues_deque.iter().enumerate() {
-            let delay = if self.pos >= idx { idx + Self::NUM_QUEUES } else { idx } - self.pos;
+            let delay = if self.pos >= idx {
+                idx + Self::NUM_QUEUES
+            } else {
+                idx
+            } - self.pos;
             for (entries, priority) in queues.0.iter().zip(Self::priorities()) {
                 for node in entries {
                     let Some((pos, _)) = blocks[node.index()] else {
@@ -290,7 +296,8 @@ impl TickScheduler {
     }
 
     fn schedule_tick(&mut self, node: NodeId, delay: usize, priority: TickPriority) {
-        self.queues_deque[(self.pos + delay) % Self::NUM_QUEUES].0[Self::priority_index(priority)].push(node);
+        self.queues_deque[(self.pos + delay) % Self::NUM_QUEUES].0[Self::priority_index(priority)]
+            .push(node);
     }
 
     fn queues_this_tick(&mut self) -> Queues {
@@ -601,7 +608,9 @@ fn schedule_tick(
     scheduler.schedule_tick(node_id, delay, priority);
 }
 
-const BOOL_INPUT_MASK: u128 = u128::from_ne_bytes([0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
+const BOOL_INPUT_MASK: u128 = u128::from_ne_bytes([
+    0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+]);
 
 fn get_bool_input(node: &Node) -> bool {
     u128::from_ne_bytes(node.default_inputs) & BOOL_INPUT_MASK != 0
@@ -614,7 +623,11 @@ fn get_bool_side(node: &Node) -> bool {
 fn last_index_positive(array: &[u8; 16]) -> u32 {
     // Note: this might be slower on big-endian systems
     let value = u128::from_le_bytes(*array);
-    if value == 0 {0} else {15 - (value.leading_zeros() >> 3)}
+    if value == 0 {
+        0
+    } else {
+        15 - (value.leading_zeros() >> 3)
+    }
 }
 
 fn get_all_input(node: &Node) -> (u8, u8) {
@@ -756,14 +769,11 @@ impl fmt::Display for DirectBackend {
             for link in node.updates.iter() {
                 let out_index = link.node().index();
                 let distance = link.ss();
-                let color = if link.side() {",color=\"blue\""} else {""}; 
+                let color = if link.side() { ",color=\"blue\"" } else { "" };
                 write!(
                     f,
                     "n{}->n{}[label=\"{}\"{}];",
-                    id,
-                    out_index,
-                    distance,
-                    color
+                    id, out_index, distance, color
                 )?;
             }
         }

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -269,7 +269,7 @@ impl TickScheduler {
 
     fn reset<W: World>(&mut self, world: &mut W, blocks: &[Option<(BlockPos, Block)>]) {
         for (idx, queues) in self.queues_deque.iter().enumerate() {
-            let delay = if self.pos >= idx { idx + 16 } else { idx } - self.pos;
+            let delay = if self.pos >= idx { idx + Self::NUM_QUEUES } else { idx } - self.pos;
             for (entries, priority) in queues.0.iter().zip(Self::priorities()) {
                 for node in entries {
                     let Some((pos, _)) = blocks[node.index()] else {

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -96,9 +96,11 @@ struct ForwardLink {
     data: u32
 }
 impl ForwardLink {
-    pub fn new(id: NodeId, side: bool, ss: u8) -> Self {
+    pub fn new(id: NodeId, side: bool, mut ss: u8) -> Self {
         assert!(id.index() < (1 << 27));
-        assert!(ss < (1 << 4));
+        if ss >= 16 {
+            ss = 15;
+        }
         Self { data:  (id.index() as u32) << 5 | if side {1 << 4} else {0} | ss as u32}
     }
     pub fn node(self) -> NodeId {

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -95,6 +95,7 @@ mod nodes {
 struct ForwardLink {
     data: u32,
 }
+
 impl ForwardLink {
     pub fn new(id: NodeId, side: bool, mut ss: u8) -> Self {
         assert!(id.index() < (1 << 27));
@@ -105,15 +106,18 @@ impl ForwardLink {
             data: (id.index() as u32) << 5 | if side { 1 << 4 } else { 0 } | ss as u32,
         }
     }
+
     pub fn node(self) -> NodeId {
         unsafe {
             // safety: ForwardLink is constructed using a NodeId
             NodeId::from_index((self.data >> 5) as usize)
         }
     }
+
     pub fn side(self) -> bool {
         self.data & (1 << 4) != 0
     }
+
     pub fn ss(self) -> u8 {
         (self.data & 0b1111) as u8
     }

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -391,6 +391,10 @@ impl DirectBackend {
             let old_power = old_power.saturating_sub(distance);
             let new_power = new_power.saturating_sub(distance);
 
+            if old_power == new_power {
+                continue;
+            }
+
             // Safety: signal strength is never larger than 15
             unsafe {
                 *inputs.get_unchecked_mut(old_power as usize) -= 1;   

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -213,8 +213,8 @@ impl Node {
                 }
             }
         }
-        stats.default_link_count += default_inputs.len();
-        stats.side_link_count += side_inputs.len();
+        stats.default_link_count += default_input_count;
+        stats.side_link_count += side_input_count;
 
         use crate::redpiler::compile_graph::NodeType as CNodeType;
         let updates = if node.ty != CNodeType::Constant {
@@ -238,7 +238,7 @@ impl Node {
 
         let ty = match node.ty {
             CNodeType::Repeater(delay) => {
-                if side_inputs.is_empty() {
+                if side_input_count == 0 {
                     NodeType::SimpleRepeater(delay)
                 } else {
                     NodeType::Repeater(delay)

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -105,7 +105,7 @@ impl ForwardLink {
     }
     pub fn node(self) -> NodeId {
         unsafe {
-            // safety: ForwardLink is contructed using a NodeId
+            // safety: ForwardLink is constructed using a NodeId
             NodeId::from_index((self.data >> 5) as usize)
         }
     }

--- a/crates/core/src/redpiler/backend/direct.rs
+++ b/crates/core/src/redpiler/backend/direct.rs
@@ -194,8 +194,8 @@ impl Node {
         let mut default_input_count = 0;
         let mut side_input_count = 0;
 
-        let mut default_inputs = NodeInput {ss_counts: [0; 16]};
-        let mut side_inputs = NodeInput {ss_counts: [0; 16]};
+        let mut default_inputs = NodeInput { ss_counts: [0; 16] };
+        let mut side_inputs = NodeInput { ss_counts: [0; 16] };
         for edge in graph.edges_directed(node_idx, Direction::Incoming) {
             let weight = edge.weight();
             let distance = weight.ss;
@@ -393,7 +393,7 @@ impl DirectBackend {
             } else {
                 &mut update_ref.default_inputs
             };
- 
+
             let old_power = old_power.saturating_sub(distance);
             let new_power = new_power.saturating_sub(distance);
 
@@ -403,7 +403,7 @@ impl DirectBackend {
 
             // Safety: signal strength is never larger than 15
             unsafe {
-                *inputs.ss_counts.get_unchecked_mut(old_power as usize) -= 1;   
+                *inputs.ss_counts.get_unchecked_mut(old_power as usize) -= 1;
                 *inputs.ss_counts.get_unchecked_mut(new_power as usize) += 1;
             }
 

--- a/crates/core/src/redpiler/passes/clamp_weights.rs
+++ b/crates/core/src/redpiler/passes/clamp_weights.rs
@@ -9,4 +9,9 @@ impl<W: World> Pass<W> for ClampWeights {
     fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
         graph.retain_edges(|g, edge| g[edge].ss < 15);
     }
+
+    fn should_run(&self, _: &CompilerOptions) -> bool {
+        // Mandatory
+        true
+    }
 }


### PR DESCRIPTION
We duplicate the signal strength of a component to all outputs, so we can get the input signal strength without having to fetch the inputs each time. Additionally by having separate buckets for each signal strength the combined input strength is calculated with just a few u128 instructions instead of having to loop over all the input.
This results in the first tenth of the chungus benchmark to only take ~7.6 on my machine while without this change it takes ~9.9 seconds, so ~30% faster.
Tested on: Ubuntu 22.04.3 LTS, intel core I7-10750H