### PR TITLE
Tweak the plot update loop

### DIFF
--- a/crates/core/src/plot/monitor.rs
+++ b/crates/core/src/plot/monitor.rs
@@ -1,4 +1,5 @@
 use mchprs_save_data::plot_data::Tps;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -44,7 +45,7 @@ struct MonitorData {
     too_slow: AtomicBool,
     ticking: AtomicBool,
     running: AtomicBool,
-    timings_record: Mutex<Vec<u32>>,
+    timings_record: Mutex<VecDeque<u32>>,
 }
 
 #[derive(Debug)]
@@ -195,9 +196,9 @@ impl TimingsMonitor {
                 // have a max size of 1800 entries.
                 let mut timings_record = data.timings_record.lock().unwrap();
                 if timings_record.len() == 1800 {
-                    timings_record.pop();
+                    timings_record.pop_back();
                 }
-                timings_record.insert(0, ticks_passed);
+                timings_record.push_front(ticks_passed);
             }
         })
     }


### PR DESCRIPTION
I wrote this PR mostly to improve the interaction between the update loop and future new backends.
Some nice side effects are that when the redpiler is reset it will no longer hang or even timeout the player in extreme cases.
This also nearly solves the issue where changes would not flush at a consistent rate at very high tick rates.
The auto redpiler feature should also work more consistently now.
I additionally changed some of the magic constants, the new values worked better for my use cases, but I would still like a second opinion on them (Especially the reduction of the max batch size to 15_000 per update, does that create any issues?).