### PR TITLE
Make world send rate changable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/core/src/plot/data.rs
+++ b/crates/core/src/plot/data.rs
@@ -1,6 +1,6 @@
 use super::{Plot, PlotWorld, PLOT_SECTIONS, PLOT_WIDTH};
 use anyhow::{Context, Result};
-use mchprs_save_data::plot_data::{ChunkData, PlotData, Tps};
+use mchprs_save_data::plot_data::{ChunkData, PlotData, Tps, WorldSendRate};
 use once_cell::sync::Lazy;
 use std::path::Path;
 use std::time::Duration;
@@ -55,6 +55,7 @@ static EMPTY_PLOT: Lazy<PlotData<PLOT_SECTIONS>> = Lazy::new(|| {
             world.chunks.iter_mut().map(|c| c.save()).collect();
         PlotData {
             tps: Tps::Limited(10),
+            world_send_rate: WorldSendRate::default(),
             chunk_data,
             pending_ticks: Vec::new(),
         }

--- a/crates/save_data/Cargo.toml
+++ b/crates/save_data/Cargo.toml
@@ -14,3 +14,4 @@ rustc-hash = "1.1"
 mchprs_world = { path = "../world" }
 mchprs_blocks = { path = "../blocks" }
 serde-big-array = "0.5"
+tracing = "0.1"

--- a/crates/save_data/src/plot_data/fixer/pre_header.rs
+++ b/crates/save_data/src/plot_data/fixer/pre_header.rs
@@ -2,7 +2,7 @@
 //! plot save file. For mchprs versions targetting 1.17.1 and below, we did
 //! not have a file header.
 
-use crate::plot_data::{ChunkData, ChunkSectionData, PlotData, Tps};
+use crate::plot_data::{ChunkData, ChunkSectionData, PlotData, Tps, WorldSendRate};
 use mchprs_blocks::block_entities::BlockEntity;
 use mchprs_blocks::BlockPos;
 use mchprs_world::TickEntry;
@@ -32,6 +32,7 @@ pub fn try_fix<const NUM_SECTIONS: usize>(data: &[u8]) -> Option<PlotData<NUM_SE
             u32::MAX => Tps::Unlimited,
             limit => Tps::Limited(limit),
         },
+        world_send_rate: WorldSendRate::default(),
         chunk_data: old_data
             .chunk_data
             .into_iter()

--- a/crates/save_data/src/plot_data/fixer/pre_worldsendrate.rs
+++ b/crates/save_data/src/plot_data/fixer/pre_worldsendrate.rs
@@ -1,0 +1,24 @@
+use crate::plot_data::{ChunkData, PlotData, Tps, WorldSendRate};
+use mchprs_world::TickEntry;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct PreSendratePlotData<const NUM_CHUNK_SECTIONS: usize> {
+    pub tps: Tps,
+    pub chunk_data: Vec<ChunkData<NUM_CHUNK_SECTIONS>>,
+    pub pending_ticks: Vec<TickEntry>,
+}
+
+pub fn try_fix<const NUM_SECTIONS: usize>(data: &[u8]) -> Option<PlotData<NUM_SECTIONS>> {
+    // Skip magic and version header
+    let data = &data[12..data.len()];
+    let old_data: PreSendratePlotData<NUM_SECTIONS> = bincode::deserialize(data).ok()?;
+
+    let data = PlotData {
+        tps: old_data.tps,
+        world_send_rate: WorldSendRate::default(),
+        chunk_data: old_data.chunk_data,
+        pending_ticks: old_data.pending_ticks,
+    };
+    Some(data)
+}


### PR DESCRIPTION
This PR add the `/worldsendrate <hertz>` (alias: `/wsr`) command to change the world send rate.
The send rate should also be persistent, so I added it to the plot data struct and had to bump the plot file version from 0 to 1.
Therefore we now have our first version based data fixer, hope I used the scaffolding as indented.
