### PR TITLE
Refactor passes/compiler and add a lot of features

### DIFF
--- a/crates/blocks/src/blocks/mod.rs
+++ b/crates/blocks/src/blocks/mod.rs
@@ -418,11 +418,23 @@ blocks! {
             sign_type: SignType,
             facing: BlockDirection
         },
-        get_id: (sign_type.0 << 3) + (facing.get_id() << 1) + 3803,
-        from_id_offset: 3803,
-        from_id(id): 3803..=3849 => {
-            sign_type: SignType(id >> 3),
-            facing: BlockDirection::from_id((id & 0b110) >> 1)
+        get_id: 1 + (sign_type.0 << 3) + (facing.get_id() << 1) + match sign_type.0 {
+            0..=5 => 3802,
+            6..=7 => 15973 - (6 << 3),
+            _ => unreachable!(),
+        },
+        from_id_offset: 0,
+        from_id(id): 3802..=3849 | 15973..=15988 => {
+            sign_type: SignType(match id {
+                3802..=3849 => (id - 3802) >> 3,
+                15973..=15988 => ((id - 15973) >> 3) + 6,
+                _ => unreachable!(),
+            }),
+            facing: BlockDirection::from_id((match id {
+                3802..=3849 => id - 3802,
+                15973..=15988 => id - 15973,
+                _ => unreachable!(),
+            } & 0b110) >> 1)
         },
         from_names(_name): {
             "oak_wall_sign" => {
@@ -437,16 +449,24 @@ blocks! {
                 sign_type: SignType(2),
                 facing: Default::default()
             },
-            "jungle_wall_sign" => {
+            "acacia_wall_sign" => {
                 sign_type: SignType(3),
                 facing: Default::default()
             },
-            "acacia_wall_sign" => {
+            "jungle_wall_sign" => {
                 sign_type: SignType(4),
                 facing: Default::default()
             },
             "dark_oak_wall_sign" => {
                 sign_type: SignType(5),
+                facing: Default::default()
+            },
+            "crimson_wall_sign" => {
+                sign_type: SignType(6),
+                facing: Default::default()
+            },
+            "warped_wall_sign" => {
+                sign_type: SignType(7),
                 facing: Default::default()
             }
         },
@@ -454,9 +474,11 @@ blocks! {
             0 => "oak_wall_sign",
             1 => "spruce_wall_sign",
             2 => "birch_wall_sign",
-            3 => "jungle_wall_sign",
-            4 => "acacia_wall_sign",
+            3 => "acacia_wall_sign",
+            4 => "jungle_wall_sign",
             5 => "dark_oak_wall_sign",
+            6 => "crimson_wall_sign",
+            7 => "warped_wall_sign",
             _ => "invalid_wall_sign"
         },
     },
@@ -511,11 +533,23 @@ blocks! {
             sign_type: SignType,
             rotation: u32
         },
-        get_id: (sign_type.0 << 5) + (rotation << 1) + 3439,
-        from_id_offset: 3439,
-        from_id(id): 3439..=3629 => {
-            sign_type: SignType(id >> 5),
-            rotation: (id & 0b11110) >> 1
+        get_id: 1 + (sign_type.0 << 5) + (rotation << 1) + match sign_type.0 {
+            0..=5 => 3438,
+            6..=7 => 15909 - (6 << 5),
+            _ => unreachable!(),
+        },
+        from_id_offset: 0,
+        from_id(id): 3438..=3629 | 15909..=15972 => {
+            sign_type: SignType(match id {
+                3438..=3629 => (id - 3438) >> 5,
+                15909..=15972 => ((id - 15909) >> 5) + 6,
+                _ => unreachable!(),
+            }),
+            rotation: (match id {
+                3438..=3629 => id - 3438,
+                15909..=15972 => id - 15909,
+                _ => unreachable!(),
+            } & 0b11110) >> 1
         },
         from_names(_name): {
             "oak_sign" => {
@@ -530,16 +564,24 @@ blocks! {
                 sign_type: SignType(2),
                 rotation: 0
             },
-            "jungle_sign" => {
+            "acacia_sign" => {
                 sign_type: SignType(3),
                 rotation: 0
             },
-            "acacia_sign" => {
+            "jungle_sign" => {
                 sign_type: SignType(4),
                 rotation: 0
             },
             "dark_oak_sign" => {
                 sign_type: SignType(5),
+                rotation: 0
+            },
+            "crimson_sign" => {
+                sign_type: SignType(6),
+                rotation: 0
+            },
+            "warped_sign" => {
+                sign_type: SignType(7),
                 rotation: 0
             }
         },
@@ -547,9 +589,11 @@ blocks! {
             0 => "oak_sign",
             1 => "spruce_sign",
             2 => "birch_sign",
-            3 => "jungle_sign",
-            4 => "acacia_sign",
+            3 => "acacia_sign",
+            4 => "jungle_sign",
             5 => "dark_oak_sign",
+            6 => "crimson_sign",
+            7 => "warped_sign",
             _ => "invalid_sign"
         },
     },

--- a/crates/blocks/src/blocks/props.rs
+++ b/crates/blocks/src/blocks/props.rs
@@ -36,7 +36,7 @@ impl RedstoneRepeater {
     }
 }
 
-#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub enum ComparatorMode {
     #[default]
     Compare,

--- a/crates/blocks/src/items.rs
+++ b/crates/blocks/src/items.rs
@@ -318,7 +318,7 @@ items! {
         },
         get_id: 768 + sign_type,
         from_id_offset: 768,
-        from_id(id): 768..=773 => {
+        from_id(id): 768..=775 => {
             sign_type: id
         },
         block: true,

--- a/crates/blocks/src/items.rs
+++ b/crates/blocks/src/items.rs
@@ -368,6 +368,10 @@ impl Item {
             "snowball" => Some(Item::Snowball {}),
             "totem_of_undying" => Some(Item::TotemOfUndying {}),
             "milk_bucket" => Some(Item::MilkBucket {}),
+            // Convert some common types of items to fix signal strength of containers
+            "redstone" => Some(Item::Redstone {}),
+            "stick" => Some(Item::Redstone {}),
+            "wooden_shovel" => Some(Item::TotemOfUndying {}),
             _ => None,
         }
     }

--- a/crates/blocks/src/lib.rs
+++ b/crates/blocks/src/lib.rs
@@ -294,6 +294,16 @@ impl BlockDirection {
             East => North,
         }
     }
+
+    pub fn from_rotation(rotation: u32) -> Option<BlockDirection> {
+        match rotation {
+            0 => Some(BlockDirection::South),
+            4 => Some(BlockDirection::West),
+            8 => Some(BlockDirection::North),
+            12 => Some(BlockDirection::East),
+            _ => None,
+        }
+    }
 }
 
 impl FromStr for BlockDirection {
@@ -422,6 +432,22 @@ impl FromStr for BlockFacing {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SignType(pub u32);
+
+impl SignType {
+    pub fn from_item_type(sign_type: u32) -> Self {
+        Self(match sign_type {
+            0 => 0, // Oak
+            1 => 1, // Spruce
+            2 => 2, // Birch
+            3 => 4, // Jungle
+            4 => 3, // Acacia
+            5 => 5, // Dark Oak
+            6 => 6, // Crimson
+            7 => 7, // Warped
+            _ => sign_type,
+        })
+    }
+}
 
 impl BlockProperty for SignType {
     // Don't encode

--- a/crates/core/src/interaction.rs
+++ b/crates/core/src/interaction.rs
@@ -182,11 +182,11 @@ pub fn get_state_for_placement(
         Item::Sign { sign_type } => match context.block_face {
             BlockFace::Bottom => Block::Air {},
             BlockFace::Top => Block::Sign {
-                sign_type: SignType(sign_type),
+                sign_type: SignType::from_item_type(sign_type),
                 rotation: (((180.0 + context.player.yaw) * 16.0 / 360.0) + 0.5).floor() as u32 & 15,
             },
             _ => Block::WallSign {
-                sign_type: SignType(sign_type),
+                sign_type: SignType::from_item_type(sign_type),
                 facing: context.block_face.unwrap_direction(),
             },
         },

--- a/crates/core/src/interaction.rs
+++ b/crates/core/src/interaction.rs
@@ -437,13 +437,19 @@ pub fn use_item_on_block(
 
         match block {
             Block::Sign { .. } | Block::WallSign { .. } => {
-                let open_sign_editor = COpenSignEditor {
-                    pos_x: block_pos.x,
-                    pos_y: block_pos.y,
-                    pos_z: block_pos.z,
+                if !item
+                    .nbt
+                    .as_ref()
+                    .is_some_and(|blob| blob.content.contains_key("BlockEntityTag"))
+                {
+                    let open_sign_editor = COpenSignEditor {
+                        pos_x: block_pos.x,
+                        pos_y: block_pos.y,
+                        pos_z: block_pos.z,
+                    }
+                    .encode();
+                    ctx.player.client.send_packet(&open_sign_editor);
                 }
-                .encode();
-                ctx.player.client.send_packet(&open_sign_editor);
             }
             _ => {}
         }

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -545,7 +545,7 @@ pub static DECLARE_COMMANDS: Lazy<PacketEncoder> = Lazy::new(|| {
                 flags: CommandFlags::ROOT.bits() as i8,
                 children: &[
                     1, 4, 5, 6, 11, 12, 14, 16, 18, 19, 20, 21, 22, 23, 24, 26, 29, 31, 32, 34, 36,
-                    47, 49, 53, 60, 61, 63,
+                    47, 49, 53, 60, 61, 63, 65, 66, 67, 71, 73,
                 ],
                 redirect_node: None,
                 name: None,
@@ -1130,6 +1130,87 @@ pub static DECLARE_COMMANDS: Lazy<PacketEncoder> = Lazy::new(|| {
                 name: Some("filename"),
                 parser: Some(Parser::String(0)),
                 suggestions_type: Some("minecraft:ask_server"),
+            },
+            // 65: /toggleautorp
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("toggleautorp"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 66: /redpiler
+            Node {
+                flags: CommandFlags::LITERAL.bits() as i8,
+                children: &[68, 69, 70], // Children are compile, inspect, reset
+                redirect_node: None,
+                name: Some("redpiler"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 67: /rp
+            Node {
+                flags: (CommandFlags::REDIRECT | CommandFlags::LITERAL).bits() as i8,
+                children: &[],
+                redirect_node: Some(66), // Redirect to /redpiler
+                name: Some("rp"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 68: /redpiler compile
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("compile"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 69: /redpiler inspect
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("inspect"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 70: /redpiler reset
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("reset"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 71: /worldsendrate
+            Node {
+                flags: (CommandFlags::LITERAL).bits() as i8,
+                children: &[72],
+                redirect_node: None,
+                name: Some("worldsendrate"),
+                parser: None,
+                suggestions_type: None,
+            },
+            // 72: /worldsendrate [rticks]
+            Node {
+                flags: (CommandFlags::ARGUMENT | CommandFlags::EXECUTABLE).bits() as i8,
+                children: &[],
+                redirect_node: None,
+                name: Some("hertz"),
+                parser: Some(Parser::Integer(0, 1000)),
+                suggestions_type: None,
+            },
+            // 73: /wsr
+            Node {
+                flags: (CommandFlags::LITERAL | CommandFlags::REDIRECT).bits() as i8,
+                children: &[],
+                redirect_node: Some(71),
+                name: Some("wsr"),
+                parser: None,
+                suggestions_type: None,
             },
         ],
         root_index: 0,

--- a/crates/core/src/redpiler/backend/direct/compile.rs
+++ b/crates/core/src/redpiler/backend/direct/compile.rs
@@ -84,16 +84,24 @@ fn compile_node(
     };
     stats.update_link_count += updates.len();
 
-    let ty = match node.ty {
-        CNodeType::Repeater(delay) => {
-            if side_input_count == 0 {
-                NodeType::SimpleRepeater(delay)
-            } else {
-                NodeType::Repeater(delay)
-            }
-        }
+    let ty = match &node.ty {
+        CNodeType::Repeater {
+            delay,
+            facing_diode,
+        } => NodeType::Repeater {
+            delay: *delay,
+            facing_diode: *facing_diode,
+        },
         CNodeType::Torch => NodeType::Torch,
-        CNodeType::Comparator(mode) => NodeType::Comparator(mode),
+        CNodeType::Comparator {
+            mode,
+            far_input,
+            facing_diode,
+        } => NodeType::Comparator {
+            mode: *mode,
+            far_input: *far_input,
+            facing_diode: *facing_diode,
+        },
         CNodeType::Lamp => NodeType::Lamp,
         CNodeType::Button => NodeType::Button,
         CNodeType::Lever => NodeType::Lever,
@@ -111,10 +119,9 @@ fn compile_node(
         powered: node.state.powered,
         output_power: node.state.output_strength,
         locked: node.state.repeater_locked,
-        facing_diode: node.facing_diode,
-        comparator_far_input: node.comparator_far_input,
         pending_tick: false,
         changed: false,
+        is_io: node.is_input || node.is_output,
     }
 }
 

--- a/crates/core/src/redpiler/backend/direct/compile.rs
+++ b/crates/core/src/redpiler/backend/direct/compile.rs
@@ -1,4 +1,3 @@
-use crate::redpiler::backend::direct::node::NonMaxU8;
 use crate::redpiler::compile_graph::{CompileGraph, LinkType, NodeIdx};
 use crate::redpiler::{CompilerOptions, TaskMonitor};
 use itertools::Itertools;
@@ -11,7 +10,7 @@ use smallvec::SmallVec;
 use std::sync::Arc;
 use tracing::trace;
 
-use super::node::{ForwardLink, Node, NodeId, NodeInput, NodeType, Nodes};
+use super::node::{ForwardLink, Node, NodeId, NodeInput, NodeType, Nodes, NonMaxU8};
 use super::DirectBackend;
 
 #[derive(Debug, Default)]

--- a/crates/core/src/redpiler/backend/direct/mod.rs
+++ b/crates/core/src/redpiler/backend/direct/mod.rs
@@ -173,14 +173,14 @@ impl JITBackend for DirectBackend {
             let Some((pos, block)) = self.blocks[i] else {
                 continue;
             };
-            if matches!(node.ty, NodeType::Comparator(_)) {
+            if matches!(node.ty, NodeType::Comparator { .. }) {
                 let block_entity = BlockEntity::Comparator {
                     output_strength: node.output_power,
                 };
                 world.set_block_entity(pos, block_entity);
             }
 
-            if io_only && !node.ty.is_io_block() {
+            if io_only && !node.is_io {
                 world.set_block(pos, block);
             }
         }
@@ -232,7 +232,7 @@ impl JITBackend for DirectBackend {
             let Some((pos, block)) = &mut self.blocks[i] else {
                 continue;
             };
-            if node.changed && (!io_only || node.ty.is_io_block()) {
+            if node.changed && (!io_only || node.is_io) {
                 if let Some(powered) = block_powered_mut(block) {
                     *powered = node.powered
                 }

--- a/crates/core/src/redpiler/backend/direct/mod.rs
+++ b/crates/core/src/redpiler/backend/direct/mod.rs
@@ -302,16 +302,16 @@ fn get_all_input(node: &Node) -> (u8, u8) {
     (input_power, side_input_power)
 }
 
+// This function is optimized for input values from 0 to 15 and does not work correctly outside that range
 fn calculate_comparator_output(mode: ComparatorMode, input_strength: u8, power_on_sides: u8) -> u8 {
-    match mode {
-        ComparatorMode::Compare => {
-            if input_strength >= power_on_sides {
-                input_strength
-            } else {
-                0
-            }
+    let difference = input_strength.wrapping_sub(power_on_sides);
+    if difference <= 15 {
+        match mode {
+            ComparatorMode::Compare => input_strength,
+            ComparatorMode::Subtract => difference,
         }
-        ComparatorMode::Subtract => input_strength.saturating_sub(power_on_sides),
+    } else {
+        0
     }
 }
 

--- a/crates/core/src/redpiler/backend/direct/mod.rs
+++ b/crates/core/src/redpiler/backend/direct/mod.rs
@@ -114,7 +114,7 @@ impl DirectBackend {
         node.output_power = new_power;
         for i in 0..node.updates.len() {
             let node = &self.nodes[node_id];
-            let update_link = node.updates[i];
+            let update_link = unsafe { *node.updates.get_unchecked(i) };
             let side = update_link.side();
             let distance = update_link.ss();
             let update = update_link.node();

--- a/crates/core/src/redpiler/backend/direct/mod.rs
+++ b/crates/core/src/redpiler/backend/direct/mod.rs
@@ -67,8 +67,7 @@ impl TickScheduler {
     }
 
     fn schedule_tick(&mut self, node: NodeId, delay: usize, priority: TickPriority) {
-        self.queues_deque[(self.pos + delay) % Self::NUM_QUEUES].0[Self::priority_index(priority)]
-            .push(node);
+        self.queues_deque[(self.pos + delay) % Self::NUM_QUEUES].0[priority as usize].push(node);
     }
 
     fn queues_this_tick(&mut self) -> Queues {
@@ -90,15 +89,6 @@ impl TickScheduler {
             TickPriority::High,
             TickPriority::Normal,
         ]
-    }
-
-    fn priority_index(priority: TickPriority) -> usize {
-        match priority {
-            TickPriority::Highest => 0,
-            TickPriority::Higher => 1,
-            TickPriority::High => 2,
-            TickPriority::Normal => 3,
-        }
     }
 }
 

--- a/crates/core/src/redpiler/backend/direct/tick.rs
+++ b/crates/core/src/redpiler/backend/direct/tick.rs
@@ -4,10 +4,10 @@ use super::*;
 impl DirectBackend {
     pub fn tick_node(&mut self, node_id: NodeId) {
         self.nodes[node_id].pending_tick = false;
-        let node = &self.nodes[node_id];
+        let node = &mut self.nodes[node_id];
 
         match node.ty {
-            NodeType::Repeater(delay) => {
+            NodeType::Repeater { delay, .. } => {
                 if node.locked {
                     return;
                 }
@@ -16,9 +16,7 @@ impl DirectBackend {
                 if node.powered && !should_be_powered {
                     self.set_node(node_id, false, 0);
                 } else if !node.powered {
-                    self.set_node(node_id, true, 15);
                     if !should_be_powered {
-                        let node = &mut self.nodes[node_id];
                         schedule_tick(
                             &mut self.scheduler,
                             node_id,
@@ -27,24 +25,7 @@ impl DirectBackend {
                             TickPriority::Higher,
                         );
                     }
-                }
-            }
-            NodeType::SimpleRepeater(delay) => {
-                let should_be_powered = get_bool_input(node);
-                if node.powered && !should_be_powered {
-                    self.set_node(node_id, false, 0);
-                } else if !node.powered {
                     self.set_node(node_id, true, 15);
-                    if !should_be_powered {
-                        let node = &mut self.nodes[node_id];
-                        schedule_tick(
-                            &mut self.scheduler,
-                            node_id,
-                            node,
-                            delay as usize,
-                            TickPriority::Higher,
-                        );
-                    }
                 }
             }
             NodeType::Torch => {
@@ -56,9 +37,11 @@ impl DirectBackend {
                     self.set_node(node_id, true, 15);
                 }
             }
-            NodeType::Comparator(mode) => {
+            NodeType::Comparator {
+                mode, far_input, ..
+            } => {
                 let (mut input_power, side_input_power) = get_all_input(node);
-                if let Some(far_override) = node.comparator_far_input {
+                if let Some(far_override) = far_input {
                     if input_power < 15 {
                         input_power = far_override;
                     }

--- a/crates/core/src/redpiler/backend/direct/tick.rs
+++ b/crates/core/src/redpiler/backend/direct/tick.rs
@@ -3,8 +3,8 @@ use super::*;
 
 impl DirectBackend {
     pub fn tick_node(&mut self, node_id: NodeId) {
-        self.nodes[node_id].pending_tick = false;
         let node = &mut self.nodes[node_id];
+        node.pending_tick = false;
 
         match node.ty {
             NodeType::Repeater { delay, .. } => {
@@ -29,12 +29,9 @@ impl DirectBackend {
                 }
             }
             NodeType::Torch => {
-                let should_be_off = get_bool_input(node);
-                let lit = node.powered;
-                if lit && should_be_off {
-                    self.set_node(node_id, false, 0);
-                } else if !lit && !should_be_off {
-                    self.set_node(node_id, true, 15);
+                let should_be_powered = !get_bool_input(node);
+                if node.powered != should_be_powered {
+                    self.set_node(node_id, should_be_powered, bool_to_ss(should_be_powered));
                 }
             }
             NodeType::Comparator {
@@ -63,7 +60,7 @@ impl DirectBackend {
                     self.set_node(node_id, false, 0);
                 }
             }
-            _ => warn!("Node {:?} should not be ticked!", node.ty),
+            _ => {} //unreachable!("Node {:?} should not be ticked!", node.ty),
         }
     }
 }

--- a/crates/core/src/redpiler/backend/direct/tick.rs
+++ b/crates/core/src/redpiler/backend/direct/tick.rs
@@ -40,7 +40,7 @@ impl DirectBackend {
                 let (mut input_power, side_input_power) = get_all_input(node);
                 if let Some(far_override) = far_input {
                     if input_power < 15 {
-                        input_power = far_override;
+                        input_power = far_override.get();
                     }
                 }
                 let old_strength = node.output_power;

--- a/crates/core/src/redpiler/backend/direct/update.rs
+++ b/crates/core/src/redpiler/backend/direct/update.rs
@@ -6,35 +6,21 @@ use super::*;
 #[inline(always)]
 pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_id: NodeId) {
     match node.ty {
-        NodeType::Repeater(delay) => {
+        NodeType::Repeater {
+            delay,
+            facing_diode,
+        } => {
             let should_be_locked = get_bool_side(node);
-            if !node.locked && should_be_locked {
-                set_node_locked(node, true);
-            } else if node.locked && !should_be_locked {
-                set_node_locked(node, false);
+            if should_be_locked != node.locked {
+                set_node_locked(node, should_be_locked);
             }
-
-            if !node.locked && !node.pending_tick {
-                let should_be_powered = get_bool_input(node);
-                if should_be_powered != node.powered {
-                    let priority = if node.facing_diode {
-                        TickPriority::Highest
-                    } else if !should_be_powered {
-                        TickPriority::Higher
-                    } else {
-                        TickPriority::High
-                    };
-                    schedule_tick(scheduler, node_id, node, delay as usize, priority);
-                }
-            }
-        }
-        NodeType::SimpleRepeater(delay) => {
-            if node.pending_tick {
+            if should_be_locked || node.pending_tick {
                 return;
             }
+
             let should_be_powered = get_bool_input(node);
-            if node.powered != should_be_powered {
-                let priority = if node.facing_diode {
+            if should_be_powered != node.powered {
+                let priority = if facing_diode {
                     TickPriority::Highest
                 } else if !should_be_powered {
                     TickPriority::Higher
@@ -54,12 +40,16 @@ pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_i
                 schedule_tick(scheduler, node_id, node, 1, TickPriority::Normal);
             }
         }
-        NodeType::Comparator(mode) => {
+        NodeType::Comparator {
+            mode,
+            far_input,
+            facing_diode,
+        } => {
             if node.pending_tick {
                 return;
             }
             let (mut input_power, side_input_power) = get_all_input(node);
-            if let Some(far_override) = node.comparator_far_input {
+            if let Some(far_override) = far_input {
                 if input_power < 15 {
                     input_power = far_override;
                 }
@@ -67,7 +57,7 @@ pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_i
             let old_strength = node.output_power;
             let output_power = calculate_comparator_output(mode, input_power, side_input_power);
             if output_power != old_strength {
-                let priority = if node.facing_diode {
+                let priority = if facing_diode {
                     TickPriority::High
                 } else {
                     TickPriority::Normal

--- a/crates/core/src/redpiler/backend/direct/update.rs
+++ b/crates/core/src/redpiler/backend/direct/update.rs
@@ -14,7 +14,7 @@ pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_i
             if should_be_locked != node.locked {
                 set_node_locked(node, should_be_locked);
             }
-            if should_be_locked || node.pending_tick {
+            if node.locked || node.pending_tick {
                 return;
             }
 
@@ -87,6 +87,6 @@ pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_i
                 node.changed = true;
             }
         }
-        _ => {} // panic!("Node {:?} should not be updated!", node.state),
+        _ => {} // unreachable!("Node {:?} should not be updated!", node.ty),
     }
 }

--- a/crates/core/src/redpiler/backend/direct/update.rs
+++ b/crates/core/src/redpiler/backend/direct/update.rs
@@ -34,9 +34,8 @@ pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_i
             if node.pending_tick {
                 return;
             }
-            let should_be_off = get_bool_input(node);
-            let lit = node.powered;
-            if lit == should_be_off {
+            let should_be_powered = !get_bool_input(node);
+            if node.powered != should_be_powered {
                 schedule_tick(scheduler, node_id, node, 1, TickPriority::Normal);
             }
         }
@@ -51,7 +50,7 @@ pub(super) fn update_node(scheduler: &mut TickScheduler, node: &mut Node, node_i
             let (mut input_power, side_input_power) = get_all_input(node);
             if let Some(far_override) = far_input {
                 if input_power < 15 {
-                    input_power = far_override;
+                    input_power = far_override.get();
                 }
             }
             let old_strength = node.output_power;

--- a/crates/core/src/redpiler/backend/mod.rs
+++ b/crates/core/src/redpiler/backend/mod.rs
@@ -28,19 +28,9 @@ pub trait JITBackend {
     fn inspect(&mut self, pos: BlockPos);
 }
 
-#[cfg(feature = "jit_cranelift")]
-use cranelift::CraneliftBackend;
 use direct::DirectBackend;
 
 #[enum_dispatch(JITBackend)]
 pub enum BackendDispatcher {
     DirectBackend,
-    #[cfg(feature = "jit_cranelift")]
-    CraneliftBackend,
-}
-
-impl Default for BackendDispatcher {
-    fn default() -> Self {
-        Self::DirectBackend(Default::default())
-    }
 }

--- a/crates/core/src/redpiler/compile_graph.rs
+++ b/crates/core/src/redpiler/compile_graph.rs
@@ -1,7 +1,6 @@
 use mchprs_blocks::blocks::ComparatorMode;
 use mchprs_blocks::BlockPos;
 use petgraph::stable_graph::{NodeIndex, StableGraph};
-use rustc_hash::FxHashSet;
 
 pub type NodeIdx = NodeIndex;
 
@@ -119,28 +118,3 @@ impl CompileLink {
 }
 
 pub type CompileGraph = StableGraph<CompileNode, CompileLink>;
-
-pub fn weakly_connected_components(graph: &CompileGraph) -> Vec<Vec<NodeIdx>> {
-    let mut visited = FxHashSet::with_capacity_and_hasher(graph.node_count(), Default::default());
-    let mut components = vec![];
-
-    for node in graph.node_indices() {
-        if !visited.contains(&node) {
-            visited.insert(node);
-
-            let mut component = vec![node];
-            let mut index = 0;
-            while component.len() > index {
-                for neighbor in graph.neighbors_undirected(component[index]) {
-                    if !visited.contains(&neighbor) {
-                        visited.insert(neighbor);
-                        component.push(neighbor);
-                    }
-                }
-                index += 1;
-            }
-            components.push(component);
-        }
-    }
-    components
-}

--- a/crates/core/src/redpiler/mod.rs
+++ b/crates/core/src/redpiler/mod.rs
@@ -142,7 +142,7 @@ impl Compiler {
             None => true,
         };
         if replace_jit {
-            debug!("Switching jit backend");
+            debug!("Switching jit backend to {:?}", options.backend_variant);
             let jit = match options.backend_variant {
                 BackendVariant::Direct => BackendDispatcher::DirectBackend(Default::default()),
             };

--- a/crates/core/src/redpiler/passes/analog_repeaters.rs
+++ b/crates/core/src/redpiler/passes/analog_repeaters.rs
@@ -1,3 +1,9 @@
+//! # [`AnalogRepeaters`]
+//!
+//! This pass optimizes all instances of "analog repeaters", by replacing them with an equivalent comparator.
+//! An analog repeater is a comparator, that is only connected to exactly 15 repeaters each with distances 0 counting to 14,
+//! and then merging into only one comparator, each with again distances 0 counting to 14.
+
 use super::Pass;
 use crate::redpiler::compile_graph::{
     Annotations, CompileGraph, CompileLink, CompileNode, LinkType, NodeIdx, NodeType,
@@ -46,6 +52,9 @@ impl<W: World> Pass<W> for AnalogRepeaters {
             else {
                 continue 'next;
             };
+            if !matches!(graph[end_idx].ty, NodeType::Comparator { .. }) {
+                continue 'next;
+            }
             let mut incomming = [false; 15];
             let mut outgoing = [false; 15];
             for &repeater in repeaters.iter() {

--- a/crates/core/src/redpiler/passes/analog_repeaters.rs
+++ b/crates/core/src/redpiler/passes/analog_repeaters.rs
@@ -1,0 +1,106 @@
+use super::Pass;
+use crate::redpiler::compile_graph::{
+    Annotations, CompileGraph, CompileLink, CompileNode, LinkType, NodeIdx, NodeType,
+};
+use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
+use itertools::Itertools;
+use mchprs_blocks::blocks::ComparatorMode;
+use petgraph::visit::{EdgeRef, NodeIndexable};
+use petgraph::Direction;
+
+pub struct AnalogRepeaters;
+
+impl<W: World> Pass<W> for AnalogRepeaters {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
+        'next: for i in 0..graph.node_bound() {
+            let start_idx = NodeIdx::new(i);
+            if !graph.contains_node(start_idx) {
+                continue;
+            }
+
+            if !matches!(graph[start_idx].ty, NodeType::Comparator { .. }) {
+                continue 'next;
+            }
+            let repeaters = graph
+                .neighbors_directed(start_idx, Direction::Outgoing)
+                .collect_vec();
+            if repeaters.len() != 15 {
+                continue 'next;
+            }
+            if !repeaters.iter().all(|&idx| {
+                graph[idx].is_removable()
+                    && matches!(
+                        graph[idx].ty,
+                        NodeType::Repeater {
+                            delay: 1,
+                            facing_diode: false
+                        }
+                    )
+            }) {
+                continue 'next;
+            }
+            let Ok(end_idx) = graph
+                .neighbors_directed(repeaters[0], Direction::Outgoing)
+                .exactly_one()
+            else {
+                continue 'next;
+            };
+            let mut incomming = [false; 15];
+            let mut outgoing = [false; 15];
+            for &repeater in repeaters.iter() {
+                let Ok(inc) = graph
+                    .edges_directed(repeater, Direction::Incoming)
+                    .exactly_one()
+                else {
+                    continue 'next;
+                };
+                let Ok(out) = graph
+                    .edges_directed(repeater, Direction::Outgoing)
+                    .exactly_one()
+                else {
+                    continue 'next;
+                };
+                if end_idx != out.target() {
+                    continue 'next;
+                }
+                if inc.weight().ty != LinkType::Default || inc.weight().ty != LinkType::Default {
+                    continue 'next;
+                }
+                if inc.weight().ss + out.weight().ss != 14 {
+                    continue 'next;
+                }
+                incomming[inc.weight().ss as usize] = true;
+                outgoing[out.weight().ss as usize] = true;
+            }
+            if incomming.into_iter().any(|x| !x) || outgoing.into_iter().any(|x| !x) {
+                continue 'next;
+            }
+
+            for &idx in repeaters.iter() {
+                graph.remove_node(idx);
+            }
+
+            let state = graph[start_idx].state.clone();
+            let new_comparator = graph.add_node(CompileNode {
+                ty: NodeType::Comparator {
+                    mode: ComparatorMode::Compare,
+                    far_input: None,
+                    facing_diode: false,
+                },
+                block: None,
+                state,
+                is_input: false,
+                is_output: false,
+                annotations: Annotations::default(),
+            });
+
+            graph.add_edge(start_idx, new_comparator, CompileLink::default(0));
+            graph.add_edge(new_comparator, end_idx, CompileLink::default(0));
+        }
+    }
+
+    fn status_message(&self) -> &'static str {
+        "Combining analog repeaters"
+    }
+}

--- a/crates/core/src/redpiler/passes/constant_coalesce.rs
+++ b/crates/core/src/redpiler/passes/constant_coalesce.rs
@@ -1,7 +1,11 @@
+use std::collections::hash_map::Entry;
+
 use super::Pass;
-use crate::redpiler::compile_graph::{weakly_connected_components, CompileGraph, NodeType};
+use crate::redpiler::compile_graph::{CompileGraph, CompileNode, NodeIdx, NodeState, NodeType};
 use crate::redpiler::{CompilerInput, CompilerOptions};
 use crate::world::World;
+use petgraph::unionfind::UnionFind;
+use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeIndexable};
 use petgraph::Direction;
 use rustc_hash::FxHashMap;
 
@@ -9,36 +13,49 @@ pub struct ConstantCoalesce;
 
 impl<W: World> Pass<W> for ConstantCoalesce {
     fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
-        let components = weakly_connected_components(graph);
-        for component in components {
-            let mut constant_nodes = FxHashMap::default();
-
-            for idx in component {
-                let node = &mut graph[idx];
-                if node.ty != NodeType::Constant || !node.is_removable() {
-                    continue;
-                }
-
-                let ss = node.state.output_strength;
-
-                match constant_nodes.get(&ss) {
-                    Some(&constant_idx) => {
-                        let mut neighbors =
-                            graph.neighbors_directed(idx, Direction::Outgoing).detach();
-                        while let Some(edge) = neighbors.next_edge(graph) {
-                            let dest = graph.edge_endpoints(edge).unwrap().1;
-                            let weight = graph.remove_edge(edge).unwrap();
-                            graph.add_edge(constant_idx, dest, weight);
-                        }
-                        graph.remove_node(idx);
-                    }
-                    None => {
-                        // Turn this node into a generic constant
-                        node.block = None;
-                        constant_nodes.insert(ss, idx);
-                    }
-                }
+        let mut vertex_sets = UnionFind::new(graph.node_bound());
+        for edge in graph.edge_references() {
+            let (src, dest) = (edge.source(), edge.target());
+            let node = &graph[src];
+            if node.ty != NodeType::Constant || !node.is_removable() {
+                vertex_sets.union(graph.to_index(src), graph.to_index(dest));
             }
+        }
+
+        let mut constant_nodes = FxHashMap::default();
+        for i in 0..graph.node_bound() {
+            let idx = NodeIdx::new(i);
+            if !graph.contains_node(idx) {
+                continue;
+            }
+            let node = &graph[idx];
+            if node.ty != NodeType::Constant || !node.is_removable() {
+                continue;
+            }
+            let ss = node.state.output_strength;
+
+            let mut neighbors = graph.neighbors_directed(idx, Direction::Outgoing).detach();
+            while let Some((edge, dest)) = neighbors.next(graph) {
+                let weight = graph.remove_edge(edge).unwrap();
+                let subgraph_component = vertex_sets.find(graph.to_index(dest));
+
+                let constant_idx = match constant_nodes.entry((subgraph_component, ss)) {
+                    Entry::Occupied(entry) => *entry.get(),
+                    Entry::Vacant(entry) => {
+                        let constant_idx = graph.add_node(CompileNode {
+                            ty: NodeType::Constant,
+                            block: None,
+                            state: NodeState::ss(ss),
+                            is_input: false,
+                            is_output: false,
+                            annotations: Default::default(),
+                        });
+                        *entry.insert(constant_idx)
+                    }
+                };
+                graph.add_edge(constant_idx, dest, weight);
+            }
+            graph.remove_node(idx);
         }
     }
 

--- a/crates/core/src/redpiler/passes/constant_coalesce.rs
+++ b/crates/core/src/redpiler/passes/constant_coalesce.rs
@@ -1,8 +1,7 @@
 use super::Pass;
-use crate::redpiler::compile_graph::{CompileGraph, NodeIdx, NodeType};
+use crate::redpiler::compile_graph::{weakly_connected_components, CompileGraph, NodeType};
 use crate::redpiler::{CompilerInput, CompilerOptions};
 use crate::world::World;
-use petgraph::visit::NodeIndexable;
 use petgraph::Direction;
 use rustc_hash::FxHashMap;
 
@@ -10,34 +9,34 @@ pub struct ConstantCoalesce;
 
 impl<W: World> Pass<W> for ConstantCoalesce {
     fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
-        let mut constant_nodes = FxHashMap::default();
+        let components = weakly_connected_components(graph);
+        for component in components {
+            let mut constant_nodes = FxHashMap::default();
 
-        for i in 0..graph.node_bound() {
-            let idx = NodeIdx::new(i);
-            if !graph.contains_node(idx) {
-                continue;
-            }
-
-            if graph[idx].ty != NodeType::Constant {
-                continue;
-            }
-
-            let ss = graph[idx].state.output_strength;
-
-            match constant_nodes.get(&graph[idx].state.output_strength) {
-                Some(&constant_idx) => {
-                    let mut neighbors = graph.neighbors_directed(idx, Direction::Outgoing).detach();
-                    while let Some(edge) = neighbors.next_edge(graph) {
-                        let dest = graph.edge_endpoints(edge).unwrap().1;
-                        let weight = graph.remove_edge(edge).unwrap();
-                        graph.add_edge(constant_idx, dest, weight);
-                    }
-                    graph.remove_node(idx);
+            for idx in component {
+                let node = &mut graph[idx];
+                if node.ty != NodeType::Constant || !node.is_removable() {
+                    continue;
                 }
-                None => {
-                    // Turn this node into a generic constant
-                    graph[idx].block = None;
-                    constant_nodes.insert(ss, idx);
+
+                let ss = node.state.output_strength;
+
+                match constant_nodes.get(&ss) {
+                    Some(&constant_idx) => {
+                        let mut neighbors =
+                            graph.neighbors_directed(idx, Direction::Outgoing).detach();
+                        while let Some(edge) = neighbors.next_edge(graph) {
+                            let dest = graph.edge_endpoints(edge).unwrap().1;
+                            let weight = graph.remove_edge(edge).unwrap();
+                            graph.add_edge(constant_idx, dest, weight);
+                        }
+                        graph.remove_node(idx);
+                    }
+                    None => {
+                        // Turn this node into a generic constant
+                        node.block = None;
+                        constant_nodes.insert(ss, idx);
+                    }
                 }
             }
         }

--- a/crates/core/src/redpiler/passes/constant_fold.rs
+++ b/crates/core/src/redpiler/passes/constant_fold.rs
@@ -63,8 +63,10 @@ fn fold(graph: &mut CompileGraph) -> usize {
         }
 
         let new_power = match graph[idx].ty {
-            NodeType::Comparator(mode) => {
-                if let Some(far_override) = graph[idx].comparator_far_input {
+            NodeType::Comparator {
+                mode, far_input, ..
+            } => {
+                if let Some(far_override) = far_input {
                     if default_power < 15 {
                         default_power = far_override;
                     }
@@ -80,7 +82,7 @@ fn fold(graph: &mut CompileGraph) -> usize {
                     ComparatorMode::Subtract => default_power.saturating_sub(side_power),
                 }
             }
-            NodeType::Repeater(_) => {
+            NodeType::Repeater { .. } => {
                 if graph[idx].state.repeater_locked {
                     graph[idx].state.output_strength
                 } else if default_power > 0 {

--- a/crates/core/src/redpiler/passes/export_graph.rs
+++ b/crates/core/src/redpiler/passes/export_graph.rs
@@ -40,11 +40,23 @@ fn convert_node(
         .map(|idx| nodes_map[&idx])
         .collect();
 
+    let facing_diode = match node.ty {
+        CNodeType::Repeater { facing_diode, .. } | CNodeType::Comparator { facing_diode, .. } => {
+            facing_diode
+        }
+        _ => false,
+    };
+
+    let comparator_far_input = match node.ty {
+        CNodeType::Comparator { far_input, .. } => far_input,
+        _ => None,
+    };
+
     Node {
         ty: match node.ty {
-            CNodeType::Repeater(delay) => NodeType::Repeater(delay),
+            CNodeType::Repeater { delay, .. } => NodeType::Repeater(delay),
             CNodeType::Torch => NodeType::Torch,
-            CNodeType::Comparator(mode) => NodeType::Comparator(match mode {
+            CNodeType::Comparator { mode, .. } => NodeType::Comparator(match mode {
                 CComparatorMode::Compare => ComparatorMode::Compare,
                 CComparatorMode::Subtract => ComparatorMode::Subtract,
             }),
@@ -71,8 +83,8 @@ fn convert_node(
             powered: node.state.powered,
             repeater_locked: node.state.repeater_locked,
         },
-        comparator_far_input: node.comparator_far_input,
-        facing_diode: node.facing_diode,
+        comparator_far_input,
+        facing_diode,
         inputs,
         updates,
     }

--- a/crates/core/src/redpiler/passes/identify_nodes.rs
+++ b/crates/core/src/redpiler/passes/identify_nodes.rs
@@ -12,7 +12,7 @@ use crate::redpiler::compile_graph::{
     Annotations, CompileGraph, CompileNode, NodeIdx, NodeState, NodeType,
 };
 use crate::redpiler::{CompilerInput, CompilerOptions};
-use crate::redstone;
+use crate::redstone::{self, comparator};
 use crate::world::{for_each_block_optimized, World};
 use itertools::Itertools;
 use mchprs_blocks::block_entities::BlockEntity;
@@ -126,7 +126,7 @@ fn identify_block<W: World>(
         Block::RedstoneComparator { comparator } => (
             NodeType::Comparator {
                 mode: comparator.mode,
-                far_input: redstone::get_comparator_far_input(world, pos, comparator.facing),
+                far_input: comparator::get_far_input(world, pos, comparator.facing),
                 facing_diode: redstone::is_diode(
                     world.get_block(pos.offset(comparator.facing.opposite().block_face())),
                 ),
@@ -154,9 +154,9 @@ fn identify_block<W: World>(
         }
         Block::IronTrapdoor { powered, .. } => (NodeType::Trapdoor, NodeState::simple(powered)),
         Block::RedstoneBlock {} => (NodeType::Constant, NodeState::ss(15)),
-        block if redstone::has_comparator_override(block) => (
+        block if comparator::has_override(block) => (
             NodeType::Constant,
-            NodeState::ss(redstone::get_comparator_override(block, world, pos)),
+            NodeState::ss(comparator::get_override(block, world, pos)),
         ),
         _ => return None,
     };

--- a/crates/core/src/redpiler/passes/identify_nodes.rs
+++ b/crates/core/src/redpiler/passes/identify_nodes.rs
@@ -8,13 +8,19 @@
 //! There are no requirements for this pass.
 
 use super::Pass;
-use crate::redpiler::compile_graph::{CompileGraph, CompileNode, NodeState, NodeType};
+use crate::redpiler::compile_graph::{
+    Annotations, CompileGraph, CompileNode, NodeIdx, NodeState, NodeType,
+};
 use crate::redpiler::{CompilerInput, CompilerOptions};
 use crate::redstone;
 use crate::world::{for_each_block_optimized, World};
+use itertools::Itertools;
 use mchprs_blocks::block_entities::BlockEntity;
-use mchprs_blocks::blocks::{Block, RedstoneComparator, RedstoneRepeater};
-use mchprs_blocks::BlockPos;
+use mchprs_blocks::blocks::Block;
+use mchprs_blocks::{BlockDirection, BlockFace, BlockPos};
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde_json::Value;
+use tracing::warn;
 
 pub struct IdentifyNodes;
 
@@ -28,11 +34,25 @@ impl<W: World> Pass<W> for IdentifyNodes {
         let ignore_wires = options.optimize;
         let plot = input.world;
 
+        let mut first_pass = FxHashMap::default();
+        let mut second_pass = FxHashSet::default();
+
         let (first_pos, second_pos) = input.bounds;
 
         for_each_block_optimized(plot, first_pos, second_pos, |pos| {
-            for_pos(ignore_wires, plot, graph, pos)
+            for_pos(
+                graph,
+                &mut first_pass,
+                &mut second_pass,
+                ignore_wires,
+                plot,
+                pos,
+            );
         });
+
+        for pos in second_pass {
+            apply_annotations(graph, options, &first_pass, plot, pos);
+        }
     }
 
     fn should_run(&self, _: &CompilerOptions) -> bool {
@@ -45,41 +65,47 @@ impl<W: World> Pass<W> for IdentifyNodes {
     }
 }
 
-fn for_pos<W: World>(ignore_wires: bool, world: &W, graph: &mut CompileGraph, pos: BlockPos) {
+fn for_pos<W: World>(
+    graph: &mut CompileGraph,
+    first_pass: &mut FxHashMap<BlockPos, NodeIdx>,
+    second_pass: &mut FxHashSet<BlockPos>,
+    ignore_wires: bool,
+    world: &W,
+    pos: BlockPos,
+) {
     let id = world.get_block_raw(pos);
     let block = Block::from_id(id);
+
+    if matches!(block, Block::Sign { .. } | Block::WallSign { .. }) {
+        second_pass.insert(pos);
+        return;
+    }
 
     let Some((ty, state)) = identify_block(block, pos, world) else {
         return;
     };
 
-    let facing_diode = match block {
-        Block::RedstoneRepeater {
-            repeater: RedstoneRepeater { facing, .. },
-            ..
-        }
-        | Block::RedstoneComparator {
-            comparator: RedstoneComparator { facing, .. },
-            ..
-        } => {
-            let facing_block = world.get_block(pos.offset(facing.opposite().block_face()));
-            redstone::is_diode(facing_block)
-        }
-        _ => false,
-    };
+    let is_input = matches!(
+        ty,
+        NodeType::Button | NodeType::Lever | NodeType::PressurePlate
+    );
+    let is_output = matches!(ty, NodeType::Trapdoor | NodeType::Lamp);
+    // || matches!(block, Block::RedstoneWire { wire } if wire::is_dot(wire));
 
-    if ignore_wires && ty == NodeType::Wire {
+    if ignore_wires && ty == NodeType::Wire && !(is_input | is_output) {
         return;
     }
 
-    graph.add_node(CompileNode {
+    let node_idx = graph.add_node(CompileNode {
         ty,
         block: Some((pos, id)),
         state,
 
-        facing_diode,
-        comparator_far_input: None,
+        is_input,
+        is_output,
+        annotations: Annotations::default(),
     });
+    first_pass.insert(pos, node_idx);
 }
 
 fn identify_block<W: World>(
@@ -89,11 +115,22 @@ fn identify_block<W: World>(
 ) -> Option<(NodeType, NodeState)> {
     let (ty, state) = match block {
         Block::RedstoneRepeater { repeater } => (
-            NodeType::Repeater(repeater.delay),
+            NodeType::Repeater {
+                delay: repeater.delay,
+                facing_diode: redstone::is_diode(
+                    world.get_block(pos.offset(repeater.facing.opposite().block_face())),
+                ),
+            },
             NodeState::repeater(repeater.powered, repeater.locked),
         ),
         Block::RedstoneComparator { comparator } => (
-            NodeType::Comparator(comparator.mode),
+            NodeType::Comparator {
+                mode: comparator.mode,
+                far_input: redstone::get_comparator_far_input(world, pos, comparator.facing),
+                facing_diode: redstone::is_diode(
+                    world.get_block(pos.offset(comparator.facing.opposite().block_face())),
+                ),
+            },
             NodeState::comparator(
                 comparator.powered,
                 if let Some(BlockEntity::Comparator { output_strength }) =
@@ -124,4 +161,87 @@ fn identify_block<W: World>(
         _ => return None,
     };
     Some((ty, state))
+}
+
+fn apply_annotations<W: World>(
+    graph: &mut CompileGraph,
+    options: &CompilerOptions,
+    first_pass: &FxHashMap<BlockPos, NodeIdx>,
+    world: &W,
+    pos: BlockPos,
+) {
+    let block = world.get_block(pos);
+    let annotations = parse_sign_annotations(world.get_block_entity(pos));
+    if annotations.is_empty() {
+        return;
+    }
+
+    let targets = match block {
+        Block::Sign { rotation, .. } => {
+            if let Some(facing) = BlockDirection::from_rotation(rotation) {
+                let behind = pos.offset(facing.opposite().block_face());
+                vec![behind]
+            } else {
+                warn!("Found sign with annotations, but bad rotation at {}", pos);
+                return;
+            }
+        }
+        Block::WallSign { facing, .. } => {
+            let behind = pos.offset(facing.opposite().block_face());
+            vec![
+                behind,
+                behind.offset(BlockFace::Top),
+                behind.offset(BlockFace::Bottom),
+            ]
+        }
+        _ => panic!("Block unimplemented for second pass"),
+    };
+
+    let target = targets.iter().flat_map(|pos| first_pass.get(pos)).next();
+    if let Some(&node_idx) = target {
+        for annotation in annotations {
+            let result = annotation.apply(graph, node_idx, options);
+            if let Err(msg) = result {
+                warn!("{} at {}", msg, pos);
+            }
+        }
+    } else {
+        warn!("Could not find component for annotation at {}", pos);
+    }
+}
+
+fn parse_sign_annotations(entity: Option<&BlockEntity>) -> Vec<NodeAnnotation> {
+    if let Some(BlockEntity::Sign(sign)) = entity {
+        sign.rows
+            .iter()
+            .flat_map(|row| serde_json::from_str(row))
+            .flat_map(|json: Value| NodeAnnotation::parse(json.as_object()?.get("text")?.as_str()?))
+            .collect_vec()
+    } else {
+        vec![]
+    }
+}
+
+pub enum NodeAnnotation {}
+
+impl NodeAnnotation {
+    fn parse(s: &str) -> Option<Self> {
+        let s = s.trim().to_ascii_lowercase();
+        if !(s.starts_with('[') && s.ends_with(']')) {
+            return None;
+        }
+        let parts = s[1..s.len() - 1].split(' ').collect_vec();
+        match parts.as_slice() {
+            _ => None,
+        }
+    }
+
+    fn apply(
+        self,
+        _graph: &mut CompileGraph,
+        _node_idx: NodeIdx,
+        _options: &CompilerOptions,
+    ) -> Result<(), String> {
+        match self {}
+    }
 }

--- a/crates/core/src/redpiler/passes/input_search.rs
+++ b/crates/core/src/redpiler/passes/input_search.rs
@@ -6,7 +6,7 @@
 use super::Pass;
 use crate::redpiler::compile_graph::{CompileGraph, CompileLink, LinkType, NodeIdx};
 use crate::redpiler::{CompilerInput, CompilerOptions};
-use crate::redstone::{self, wire};
+use crate::redstone::{self, comparator, wire};
 use crate::world::World;
 use mchprs_blocks::blocks::{Block, ButtonFace, LeverFace};
 use mchprs_blocks::{BlockDirection, BlockFace, BlockPos};
@@ -307,7 +307,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
 
                 let input_pos = pos.offset(facing.block_face());
                 let input_block = self.world.get_block(input_pos);
-                if redstone::has_comparator_override(input_block) {
+                if comparator::has_override(input_block) {
                     self.graph
                         .add_edge(self.pos_map[&input_pos], id, CompileLink::default(0));
                 } else {

--- a/crates/core/src/redpiler/passes/input_search.rs
+++ b/crates/core/src/redpiler/passes/input_search.rs
@@ -312,18 +312,6 @@ impl<'a, W: World> InputSearchState<'a, W> {
                         .add_edge(self.pos_map[&input_pos], id, CompileLink::default(0));
                 } else {
                     self.search_diode_inputs(id, pos, facing);
-
-                    let far_input_pos = input_pos.offset(facing.block_face());
-                    let far_input_block = self.world.get_block(far_input_pos);
-                    if input_block.is_solid() && redstone::has_comparator_override(far_input_block)
-                    {
-                        let far_override = redstone::get_comparator_override(
-                            far_input_block,
-                            self.world,
-                            far_input_pos,
-                        );
-                        self.graph[id].comparator_far_input = Some(far_override);
-                    }
                 }
             }
             Block::RedstoneRepeater { repeater } => {

--- a/crates/core/src/redpiler/passes/mod.rs
+++ b/crates/core/src/redpiler/passes/mod.rs
@@ -1,3 +1,4 @@
+mod analog_repeaters;
 mod clamp_weights;
 mod coalesce;
 mod constant_coalesce;
@@ -24,6 +25,7 @@ pub const fn make_default_pass_manager<'w, W: World>() -> PassManager<'w, W> {
         &input_search::InputSearch,
         &clamp_weights::ClampWeights,
         &dedup_links::DedupLinks,
+        &analog_repeaters::AnalogRepeaters,
         &constant_fold::ConstantFold,
         &unreachable_output::UnreachableOutput,
         &constant_coalesce::ConstantCoalesce,

--- a/crates/core/src/redpiler/passes/mod.rs
+++ b/crates/core/src/redpiler/passes/mod.rs
@@ -6,6 +6,7 @@ mod dedup_links;
 mod export_graph;
 mod identify_nodes;
 mod input_search;
+mod prune_orphans;
 mod unreachable_output;
 
 use crate::world::World;
@@ -27,6 +28,7 @@ pub const fn make_default_pass_manager<'w, W: World>() -> PassManager<'w, W> {
         &unreachable_output::UnreachableOutput,
         &constant_coalesce::ConstantCoalesce,
         &coalesce::Coalesce,
+        &prune_orphans::PruneOrphans,
         &export_graph::ExportGraph,
     ])
 }

--- a/crates/core/src/redpiler/passes/prune_orphans.rs
+++ b/crates/core/src/redpiler/passes/prune_orphans.rs
@@ -1,0 +1,39 @@
+//! # [`PruneOrphans`]
+//!
+//! This pass removes any nodes in the graph that aren't transitively connected to an output redstone component by using Depth-First-Search.
+
+use super::Pass;
+use crate::redpiler::compile_graph::CompileGraph;
+use crate::redpiler::{CompilerInput, CompilerOptions};
+use crate::world::World;
+use itertools::Itertools;
+use petgraph::Direction;
+use rustc_hash::FxHashSet;
+
+pub struct PruneOrphans;
+
+impl<W: World> Pass<W> for PruneOrphans {
+    fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
+        let mut to_visit = graph
+            .node_indices()
+            .filter(|&idx| !graph[idx].is_removable())
+            .collect_vec();
+
+        let mut visited = FxHashSet::default();
+        while let Some(idx) = to_visit.pop() {
+            if visited.insert(idx) {
+                to_visit.extend(graph.neighbors_directed(idx, Direction::Incoming));
+            }
+        }
+
+        graph.retain_nodes(|_, idx| visited.contains(&idx));
+    }
+
+    fn should_run(&self, options: &CompilerOptions) -> bool {
+        options.io_only && options.optimize
+    }
+
+    fn status_message(&self) -> &'static str {
+        "Pruning orphans"
+    }
+}

--- a/crates/core/src/redpiler/passes/unreachable_output.rs
+++ b/crates/core/src/redpiler/passes/unreachable_output.rs
@@ -26,7 +26,13 @@ impl<W: World> Pass<W> for UnreachableOutput {
                 continue;
             }
 
-            if graph[idx].ty != NodeType::Comparator(ComparatorMode::Subtract) {
+            if !matches!(
+                graph[idx].ty,
+                NodeType::Comparator {
+                    mode: ComparatorMode::Subtract,
+                    ..
+                }
+            ) {
                 continue;
             }
 

--- a/crates/core/src/redstone/mod.rs
+++ b/crates/core/src/redstone/mod.rs
@@ -355,7 +355,7 @@ pub fn get_comparator_far_input(
     pos: BlockPos,
     facing: BlockDirection,
 ) -> Option<u8> {
-    let face = facing.opposite().block_face();
+    let face = facing.block_face();
     let input_pos = pos.offset(face);
     let input_block = world.get_block(input_pos);
     if !input_block.is_solid() || has_comparator_override(input_block) {

--- a/crates/core/src/redstone/mod.rs
+++ b/crates/core/src/redstone/mod.rs
@@ -318,63 +318,6 @@ pub fn update_surrounding_blocks(world: &mut impl World, pos: BlockPos) {
     }
 }
 
-pub fn has_comparator_override(block: Block) -> bool {
-    matches!(
-        block,
-        Block::Barrel { .. }
-            | Block::Furnace { .. }
-            | Block::Hopper { .. }
-            | Block::Cauldron { .. }
-            | Block::Composter { .. }
-            | Block::Cake { .. }
-    )
-}
-
-pub fn get_comparator_override(block: Block, world: &impl World, pos: BlockPos) -> u8 {
-    match block {
-        Block::Barrel { .. } | Block::Furnace { .. } | Block::Hopper { .. } => {
-            if let Some(BlockEntity::Container {
-                comparator_override,
-                ..
-            }) = world.get_block_entity(pos)
-            {
-                *comparator_override
-            } else {
-                0
-            }
-        }
-        Block::Cauldron { level } => level,
-        Block::Composter { level } => level,
-        Block::Cake { bites } => 14 - 2 * bites,
-        _ => 0,
-    }
-}
-
-pub fn get_comparator_far_input(
-    world: &impl World,
-    pos: BlockPos,
-    facing: BlockDirection,
-) -> Option<u8> {
-    let face = facing.block_face();
-    let input_pos = pos.offset(face);
-    let input_block = world.get_block(input_pos);
-    if !input_block.is_solid() || has_comparator_override(input_block) {
-        return None;
-    }
-
-    let far_input_pos = input_pos.offset(face);
-    let far_input_block = world.get_block(far_input_pos);
-    if has_comparator_override(far_input_block) {
-        Some(get_comparator_override(
-            far_input_block,
-            world,
-            far_input_pos,
-        ))
-    } else {
-        None
-    }
-}
-
 pub fn is_diode(block: Block) -> bool {
     matches!(
         block,

--- a/crates/core/src/redstone/mod.rs
+++ b/crates/core/src/redstone/mod.rs
@@ -350,6 +350,31 @@ pub fn get_comparator_override(block: Block, world: &impl World, pos: BlockPos) 
     }
 }
 
+pub fn get_comparator_far_input(
+    world: &impl World,
+    pos: BlockPos,
+    facing: BlockDirection,
+) -> Option<u8> {
+    let face = facing.opposite().block_face();
+    let input_pos = pos.offset(face);
+    let input_block = world.get_block(input_pos);
+    if !input_block.is_solid() || has_comparator_override(input_block) {
+        return None;
+    }
+
+    let far_input_pos = input_pos.offset(face);
+    let far_input_block = world.get_block(far_input_pos);
+    if has_comparator_override(far_input_block) {
+        Some(get_comparator_override(
+            far_input_block,
+            world,
+            far_input_pos,
+        ))
+    } else {
+        None
+    }
+}
+
 pub fn is_diode(block: Block) -> bool {
     matches!(
         block,

--- a/crates/core/src/redstone/wire/mod.rs
+++ b/crates/core/src/redstone/wire/mod.rs
@@ -193,14 +193,14 @@ pub fn get_regulated_sides(wire: RedstoneWire, world: &impl World, pos: BlockPos
     state
 }
 
-fn is_dot(wire: RedstoneWire) -> bool {
+pub(crate) fn is_dot(wire: RedstoneWire) -> bool {
     wire.north == RedstoneWireSide::None
         && wire.south == RedstoneWireSide::None
         && wire.east == RedstoneWireSide::None
         && wire.west == RedstoneWireSide::None
 }
 
-fn is_cross(wire: RedstoneWire) -> bool {
+pub(crate) fn is_cross(wire: RedstoneWire) -> bool {
     wire.north == RedstoneWireSide::Side
         && wire.south == RedstoneWireSide::Side
         && wire.east == RedstoneWireSide::Side

--- a/crates/network/src/packets/mod.rs
+++ b/crates/network/src/packets/mod.rs
@@ -373,7 +373,7 @@ impl PacketEncoder {
         PacketEncoder { buffer, packet_id }
     }
 
-    // This function is seperate because it is needed when writing packet headers
+    // This function is separate because it is needed when writing packet headers
     fn varint(val: i32) -> Vec<u8> {
         let mut val = val as u32;
         let mut buf = Vec::new();

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TickPriority {
-    Highest,
-    Higher,
-    High,
-    Normal,
+    Highest = 0,
+    Higher = 1,
+    High = 2,
+    Normal = 3,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/docs/Redpiler.md
+++ b/docs/Redpiler.md
@@ -34,6 +34,12 @@ The links created in the `InputSearch` pass are weighted by the distance taken i
 
 Sometimes, the breadth-first search done by the `InputSearch` pass can result in two different paths to the same node. While this would not cause any problems during execution, it is still inefficent. This optimization pass removes duplicate links to the same node, only keeping the link with the lowest weight. For example, if two nodes are connected with two links of weights 13 and 15, the link with weight 15 is removed.
 
+# The [`AnalogRepeaters`] Pass
+
+This pass optimizes all instances of "analog repeaters", by replacing them with an equivalent comparator.
+An analog repeater is a comparator, that is only connected to exactly 15 repeaters each with distances 0 counting to 14,
+and then merging into only one comparator, each with again distances 0 counting to 14.
+
 ## The `ConstantFold` Pass
 
 While nodes that are never updated in theory have no affect on the number of instructions that are run at runtime, therefore the time taken to perform a tick at runtime, keeping the size of the graph small helps to avoid cache misses that to end up taking time at runtime. This optimization pass reduces the size of the final graph by recognizing situations where a node only has constant inputs and tranforming that node into a constant node, breaking the links to the other constant nodes.

--- a/docs/Redpiler.md
+++ b/docs/Redpiler.md
@@ -10,7 +10,7 @@ Redpiler was inspired by the design of modern compilers such as LLVM. As such, R
 
 ## The `IdentifyNodes` Pass
 
-At the start of the compile, the graph is completely empty. This mandatory pass populates the graph with nodes using the given input world. This input is usually the plot the player is in, but it can also be a WorldEdit selection if Redpiler was invoked with certain flags. 
+At the start of the compile, the graph is completely empty. This mandatory pass populates the graph with nodes using the given input world. This input is usually the plot the player is in, but it can also be a WorldEdit selection if Redpiler was invoked with certain flags.
 
 The pass iterates through all the blocks in the input, and tries to identify them as Redstone components. If a block is a Repeater, Comparator, Torch, Stone Button, Lamp, Lever, Stone Pressure Plate, a new node is created in the graph with the appropriate node type containing the necessary state information. If an optimization flag is not set, Redstone Wires are also added to the graph.
 
@@ -18,7 +18,7 @@ Blocks that have a comparator override such as Barrels, Furnaces, Hoppers, Cauld
 
 ## The `InputSearch` Pass
 
-Now that the graph been populated with nodes, Redpiler can now start finding the connections between Redstone components. This mandatory pass populates the graph with links. 
+Now that the graph been populated with nodes, Redpiler can now start finding the connections between Redstone components. This mandatory pass populates the graph with links.
 
 This pass is the most complex out of them all, but it is also one of the most important aspects of Redpiler. One of the major reasons vanilla Minecraft is so slow at processing redstone is because of  the fact that when a component is updated, which can happen several times in a tick, it has to look for all sources of input. This can take a relatively very long time, and Redpiler solves this issue by only looking once and saving this information in the form of the links in the graph.
 
@@ -40,17 +40,22 @@ While nodes that are never updated in theory have no affect on the number of ins
 
 ## The `UnreachableOutput` Pass
 
-If the side of a Comparator in subtract mode is constant, then the maximum output of the comparator is equal to the difference of the maximum side input and the maximum default input. Outgoing links that have a weight greater than or equal to the maxium output of the comparator can be safely removed. 
+If the side of a Comparator in subtract mode is constant, then the maximum output of the comparator is equal to the difference of the maximum side input and the maximum default input. Outgoing links that have a weight greater than or equal to the maxium output of the comparator can be safely removed.
 
 This optimization implements a simplified version of this idea. First, it iterates through all comparators in subtract mode and checks if a comparator has a single constant side input. If it does, it takes the difference between 15 and the constant strength, clamped at 0. If there are any outgoing links that have a weight greater than or equal to the difference, then it is removed from the graph.
 
 ## The `ConstantCoalesce` Pass
 
-Disregarding High-Signal Strength logic, which Redpiler does not support anyways, the value of a constant is ever only in between 0 and 15. Effectively, there are only 16 different constant values possible. This optimization pass creates the 16 different constant nodes for all values, and removes all other constant nodes in the graph. The outgoing edges of the old constant nodes are transformed to source from the new constant nodes. 
+Disregarding High-Signal Strength logic, which Redpiler does not support anyways, the value of a constant is ever only in between 0 and 15. Effectively, there are only 16 different constant values possible. This optimization pass creates the 16 different constant nodes for all values, and removes all other constant nodes in the graph. The outgoing edges of the old constant nodes are transformed to source from the new constant nodes.
 
 ## The `Coalesce` Pass
 
 There are often times when a wire powers many different components in the same way. For example, it is common for vertical multi-bit latches to be controlled by a slab tower that powers several repetears that lock other repeaters. This is very inefficent because these repeaters will always have the exact same value, but they are still updated and ticked independently. To avoid this logic duplication, this optimization pass merges duplicate nodes into one, removing duplicate nodes from the graph and adjusting links to point to the new node.
+
+## The `PruneOrphans` Pass
+
+Any redstone components that do not contribute to the functioning of output components (Trapdoors and Lamps) can be disregarded.
+This pass recusively marks all nodes connected to an output node and removes all remaining unmarked nodes (Depth-First-Search).
 
 ## The `ExportGraph` Pass
 
@@ -58,7 +63,7 @@ This pass is neither a mandatory pass nor an optimization pass. This pass is onl
 
 # The Backend
 
-Once the graph has been created, it is sent to a Redpiler backend which is responsible for the runtime execution of the Redstone circuit. A backend may implement redstone executation in any way, whether that is by just-in-time compiling redstone or by interpreting the graph. 
+Once the graph has been created, it is sent to a Redpiler backend which is responsible for the runtime execution of the Redstone circuit. A backend may implement redstone executation in any way, whether that is by just-in-time compiling redstone or by interpreting the graph.
 
 ## How Redstone Works
 


### PR DESCRIPTION
I extracted all the non destructive changes from my feature branches into one "nice" PR.
A lot of the changes are useful by themself. However this is mostly so I don't go insane rebasing stuff every few weeks, as my branches have diverged too far from the main branch by now.

Changelog:
- Added the remaining sign types
- Allow signs to be picked/placed with NBT data
- Add tab-complete to commonly used commands that were currently missing it
- Move specific immutable properties from `Node` to `NodeType` for Compiler and Backend
  - Moved `facing_diode` to Repeater and Comparator only
  - Moved `far_input` to Comparator variant
- Improved the Compilers and Backends understanding of what is considered "relevant"
  - Compiler passes now don't optimize away nodes that are considered inputs or outputs
  - Backend now gets information from the Compiler which blocks it should consider io, important for flushing in io_only mode
 - Removed SimpleRepeater as it actually slightly decreases performance after Bram's patch
 - Prepared for addition of new Backends by implementing Backend switching
 - Added a compiler pass that combines the 15 repeaters of ["analog repeaters"](https://newcaledoniadevteam.github.io/MountainsGuide/redstone/#analog-repeater-wire) into one comparator
 - Added a compiler pass that removes all nodes not transitively connected to an output node (only runs when io_only and optimization is enabled)
 - Modified constant_coalesce pass so that it won't coalesce constants that belong to different unconncted builds (This is one of the few changes that improve nothing for now and is mostly so that my threading doesn't break)
 - Added an annotation system using signs, implemented as a second pass in the identify nodes compiler pass for optimization reasons (Currently there are no annotations implemented, but in the future it will be useful to, for example, automatically print the state of redstone components etc.)
 - A lot of other minor stuff