### PR TITLE
play note when adjusting noteblock pitch

### DIFF
--- a/crates/core/src/interaction.rs
+++ b/crates/core/src/interaction.rs
@@ -3,6 +3,7 @@ use crate::player::Player;
 use crate::plot::PlotWorld;
 use crate::plot::PLOT_BLOCK_HEIGHT;
 use crate::redstone;
+use crate::redstone::noteblock;
 use crate::world::World;
 use mchprs_blocks::block_entities::BlockEntity;
 use mchprs_blocks::blocks::*;
@@ -88,19 +89,21 @@ pub fn on_use(
             }
             ActionResult::Success
         }
-        Block::NoteBlock {
-            instrument,
-            note,
-            powered,
-        } => {
+        Block::NoteBlock { note, powered, .. } => {
+            let note = (note + 1) % 25;
+            let instrument = noteblock::get_noteblock_instrument(world, pos);
+
             world.set_block(
                 pos,
                 Block::NoteBlock {
                     instrument,
-                    note: (note + 1) % 25,
+                    note,
                     powered,
                 },
             );
+
+            noteblock::play_note(world, pos, instrument, note);
+
             ActionResult::Success
         }
         b if b.has_block_entity() => {

--- a/crates/core/src/interaction.rs
+++ b/crates/core/src/interaction.rs
@@ -102,7 +102,9 @@ pub fn on_use(
                 },
             );
 
-            noteblock::play_note(world, pos, instrument, note);
+            if noteblock::is_noteblock_unblocked(world, pos) {
+                noteblock::play_note(world, pos, instrument, note);
+            }
 
             ActionResult::Success
         }


### PR DESCRIPTION
makes it easier to tune note blocks
it seams that the instrument isn't updated immediately when the block under the noteblock changes which is why we use get_noteblock_instrument here.
It may make more sense to keep the blockstate in sync instead of looking for the block beneath whenever a note needs to be played, as this is also the way minecraft java does it.