### PR TITLE
add glowstone placement (only broken noteblock instrument)

### DIFF
--- a/crates/blocks/src/items.rs
+++ b/crates/blocks/src/items.rs
@@ -2,7 +2,7 @@ use crate::block_entities::ContainerType;
 use crate::BlockColorVariant;
 use mchprs_utils::map;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ItemStack {
     pub item_type: Item,
     pub count: u8,
@@ -182,6 +182,12 @@ items! {
         props: {},
         get_id: 143,
         from_id(_id): 143 => {},
+        block: true,
+    },
+    Glowstone {
+        props: {},
+        get_id: 275,
+        from_id(_id): 275 => {},
         block: true,
     },
     Sandstone {

--- a/crates/core/src/interaction.rs
+++ b/crates/core/src/interaction.rs
@@ -129,6 +129,7 @@ pub fn get_state_for_placement(
     let block = match item {
         Item::Stone {} => Block::Stone {},
         Item::Glass {} => Block::Glass {},
+        Item::Glowstone {} => Block::Glowstone {},
         Item::Sandstone {} => Block::Sandstone {},
         Item::SeaPickle {} => Block::SeaPickle { pickles: 1 },
         Item::Wool { color } => Block::Wool { color },


### PR DESCRIPTION
I was trying out the different noteblocks a noticed that glowstone was broken. Looks like it was simply never added.