### PR TITLE
Fix and simplify `world::for_each_block_optimized`

### DIFF
--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -432,9 +432,11 @@ mod test {
         );
     }
 
+    // mock World implementation for tests in this module,
+    // we don't need most of the methods
     impl World for TestWorld {
         fn get_block_raw(&self, pos: BlockPos) -> u32 {
-            todo!()
+            unimplemented!()
         }
 
         fn set_block_raw(&mut self, pos: BlockPos, block: u32) -> bool {
@@ -450,15 +452,15 @@ mod test {
         }
 
         fn delete_block_entity(&mut self, pos: BlockPos) {
-            todo!()
+            unimplemented!()
         }
 
         fn get_block_entity(&self, pos: BlockPos) -> Option<&BlockEntity> {
-            todo!()
+            unimplemented!()
         }
 
         fn set_block_entity(&mut self, pos: BlockPos, block_entity: BlockEntity) {
-            todo!()
+            unimplemented!()
         }
 
         fn get_chunk(&self, x: i32, z: i32) -> Option<&Chunk> {
@@ -470,11 +472,11 @@ mod test {
         }
 
         fn schedule_tick(&mut self, pos: BlockPos, delay: u32, priority: TickPriority) {
-            todo!()
+            unimplemented!()
         }
 
         fn pending_tick_at(&mut self, pos: BlockPos) -> bool {
-            todo!()
+            unimplemented!()
         }
     }
 }


### PR DESCRIPTION
First time contributor, so please let me know if I'm doing anything wrong.

I was looking at the source for no particular reason at all and decided to take a stab at this:
https://github.com/MCHPR/MCHPRS/blob/76b9b8cf575ee4419eca5c2cd9dac56405a2cafe/crates/world/src/lib.rs#L84
finding a bug in the process.

This PR replaces the duplicated implementation of `for_each_block_optimized` and
`for_each_block_mut_optimized` in the `mchprs_world` crate with a simpler implementation
that abstracts the iteration logic.

Also this adds tests for the iteration logic and for the `for_each_block_optimized` function
(which is how I realised that the current implementation had a bug that could lead
to some non-air block being skipped, see #168 for more details); let me know if
they're too verbose or if there should be other cases covered.

With the new implementation #168 should be fixed, since the new iteration special-cases
the bounding box boundaries and otherwise checks the block in batches corresponding
to chunk sections.
