### PR TITLE
Add tickn method to redpiler JITBackend trait

### DIFF
--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -321,9 +321,8 @@ impl Plot {
                     return false;
                 };
                 let start_time = Instant::now();
-                for _ in 0..ticks {
-                    self.tick();
-                }
+                self.tickn(ticks as u64);
+
                 if self.redpiler.is_active() {
                     self.redpiler.flush(&mut self.world);
                 }

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -269,6 +269,18 @@ impl World for PlotWorld {
 }
 
 impl Plot {
+    fn tickn(&mut self, ticks: u64) {
+        if self.redpiler.is_active() {
+            self.timings.tickn(ticks);
+            self.redpiler.tickn(ticks);
+            return;
+        }
+
+        for _ in 0..ticks {
+            self.tick();
+        }
+    }
+
     fn tick(&mut self) {
         self.timings.tick();
         if self.redpiler.is_active() {
@@ -1012,9 +1024,7 @@ impl Plot {
                 let batch_size = batch_size.min(50_000) as u32;
                 let mut ticks_completed = batch_size;
                 if self.redpiler.is_active() {
-                    for _ in 0..batch_size {
-                        self.tick();
-                    }
+                    self.tickn(batch_size as u64);
                     self.redpiler.flush(&mut self.world);
                 } else {
                     for i in 0..batch_size {

--- a/crates/core/src/plot/monitor.rs
+++ b/crates/core/src/plot/monitor.rs
@@ -129,7 +129,7 @@ impl TimingsMonitor {
     pub fn tick(&self) {
         self.data.ticks_passed.fetch_add(1, Ordering::Relaxed);
     }
-    
+
     pub fn tickn(&self, ticks: u64) {
         self.data.ticks_passed.fetch_add(ticks, Ordering::Relaxed);
     }

--- a/crates/core/src/plot/monitor.rs
+++ b/crates/core/src/plot/monitor.rs
@@ -129,6 +129,10 @@ impl TimingsMonitor {
     pub fn tick(&self) {
         self.data.ticks_passed.fetch_add(1, Ordering::Relaxed);
     }
+    
+    pub fn tickn(&self, ticks: u64) {
+        self.data.ticks_passed.fetch_add(ticks, Ordering::Relaxed);
+    }
 
     pub fn is_running_behind(&self) -> bool {
         self.data.too_slow.load(Ordering::Relaxed)

--- a/crates/redpiler/src/backend/mod.rs
+++ b/crates/redpiler/src/backend/mod.rs
@@ -19,6 +19,13 @@ pub trait JITBackend {
         monitor: Arc<TaskMonitor>,
     );
     fn tick(&mut self);
+
+    fn tickn(&mut self, ticks: u64) {
+        for _ in 0..ticks {
+            self.tick();
+        }
+    }
+
     fn on_use_block(&mut self, pos: BlockPos);
     fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool);
     fn flush<W: World>(&mut self, world: &mut W, io_only: bool);

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -203,7 +203,7 @@ impl Compiler {
     pub fn tick(&mut self) {
         self.backend().tick();
     }
-    
+
     pub fn tickn(&mut self, ticks: u64) {
         self.backend().tickn(ticks);
     }

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -203,6 +203,10 @@ impl Compiler {
     pub fn tick(&mut self) {
         self.backend().tick();
     }
+    
+    pub fn tickn(&mut self, ticks: u64) {
+        self.backend().tickn(ticks);
+    }
 
     pub fn on_use_block(&mut self, pos: BlockPos) {
         self.backend().on_use_block(pos);


### PR DESCRIPTION
Adds a method called tickn to the redpiler JITBackend trait which executes multiple ticks per call instead of just one

While right now the overhead of going through all the abstraction layers is minimal there is still a very small overhead.
But more importantly allowing the backends to have their own implementations can allow for other backends to do specific optimizations.
For example a threaded backend could have parts of a circuit be slightly out of sync if this doesn't effect the functioning of the circuit and then sync back up at the end.
Or ticks could be skipped if no ticks are in the queue.