### PR TITLE
Fix: repeater tick not scheduling at the end of the tick

### DIFF
--- a/crates/redpiler/src/backend/direct/tick.rs
+++ b/crates/redpiler/src/backend/direct/tick.rs
@@ -16,7 +16,9 @@ impl DirectBackend {
                 if node.powered && !should_be_powered {
                     self.set_node(node_id, false, 0);
                 } else if !node.powered {
+                    self.set_node(node_id, true, 15);
                     if !should_be_powered {
+                        let node = &mut self.nodes[node_id];
                         schedule_tick(
                             &mut self.scheduler,
                             node_id,
@@ -25,7 +27,6 @@ impl DirectBackend {
                             TickPriority::Higher,
                         );
                     }
-                    self.set_node(node_id, true, 15);
                 }
             }
             NodeType::Torch => {

--- a/crates/redpiler/src/backend/direct/tick.rs
+++ b/crates/redpiler/src/backend/direct/tick.rs
@@ -17,8 +17,8 @@ impl DirectBackend {
                     self.set_node(node_id, false, 0);
                 } else if !node.powered {
                     self.set_node(node_id, true, 15);
-                    if !should_be_powered {
-                        let node = &mut self.nodes[node_id];
+                    let node = &mut self.nodes[node_id];
+                    if !should_be_powered & !node.pending_tick {
                         schedule_tick(
                             &mut self.scheduler,
                             node_id,

--- a/crates/redstone/src/repeater.rs
+++ b/crates/redstone/src/repeater.rs
@@ -95,5 +95,8 @@ pub fn tick(mut rep: RedstoneRepeater, world: &mut impl World, pos: BlockPos) {
         rep.powered = true;
         world.set_block(pos, Block::RedstoneRepeater { repeater: rep });
         on_state_change(rep, world, pos);
+        if !should_be_powered {
+            world.schedule_tick(pos, rep.delay as u32, TickPriority::Higher);
+        }
     }
 }

--- a/crates/redstone/src/repeater.rs
+++ b/crates/redstone/src/repeater.rs
@@ -95,7 +95,7 @@ pub fn tick(mut rep: RedstoneRepeater, world: &mut impl World, pos: BlockPos) {
         rep.powered = true;
         world.set_block(pos, Block::RedstoneRepeater { repeater: rep });
         on_state_change(rep, world, pos);
-        if !should_be_powered {
+        if !should_be_powered && !world.pending_tick_at(pos) {
             world.schedule_tick(pos, rep.delay as u32, TickPriority::Higher);
         }
     }


### PR DESCRIPTION
There was an inconsistency between the normal ticking and the ticking of the redpiler direct backend
Where redpiler could schedule a tick inside of the tick method but the normal tick could not.
This might also explain some inconsistent behaviour between redpiler and the normal tick but I have not tested this yet.

Additionally it seems vanilla schedules this tick after updating the block-state while redpiler did this before updating.

I have tested the changes on Iris with the mandlebrot program on redpiler and it does not seem to break things, I haven't tested it much outside of that yet.
So I do still need to test the default backend.