### PR TITLE
Optimize get_bool_input and get_bool_side

### DIFF
--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -67,6 +67,10 @@ fn compile_node(
     stats.default_link_count += default_input_count;
     stats.side_link_count += side_input_count;
 
+    // Make sure signal strength buckets add up to 255 so we can easily check for all zeros in get_bool_input
+    default_inputs.ss_counts[0] += (MAX_INPUTS - default_input_count) as u8;
+    side_inputs.ss_counts[0] += (MAX_INPUTS - side_input_count) as u8;
+
     use crate::compile_graph::NodeType as CNodeType;
     let updates = if node.ty != CNodeType::Constant {
         graph

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -308,16 +308,14 @@ fn schedule_tick(
     scheduler.schedule_tick(node_id, delay, priority);
 }
 
-const BOOL_INPUT_MASK: u128 = u128::from_ne_bytes([
-    0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-]);
-
 fn get_bool_input(node: &Node) -> bool {
-    u128::from_le_bytes(node.default_inputs.ss_counts) & BOOL_INPUT_MASK != 0
+    // During compilation its ensured all signal strength buckets add up to 255
+    // So if and only if the zero bucket contains 255 is the input zero
+    node.default_inputs.ss_counts[0] != 255
 }
 
 fn get_bool_side(node: &Node) -> bool {
-    u128::from_le_bytes(node.side_inputs.ss_counts) & BOOL_INPUT_MASK != 0
+    node.side_inputs.ss_counts[0] != 255
 }
 
 fn last_index_positive(array: &[u8; 16]) -> u32 {


### PR DESCRIPTION
Similar to https://github.com/BramOtte/MCHPRS/tree/optimize-boolean-edges-2
this change optimizes for the fact that most components don't care about signal strength but only about on or off.
But this optimization is much simpler and does not skip out on updates but simply makes them slightly faster.
This means the gains are likely smaller but the likelihood of this breaking anything is very small.

This optimization results in about a 6% rtps increase when running the Iris Mandelbrot program.
Tested on ubuntu 20.04 on an Intel core i7-10750H over multiple runs