### PR TITLE
Add -s flag to //stack worldedit command

### DIFF
--- a/crates/core/src/plot/worldedit/execute.rs
+++ b/crates/core/src/plot/worldedit/execute.rs
@@ -356,6 +356,13 @@ pub(super) fn execute_stack(ctx: CommandExecuteContext<'_>) {
     };
     ctx.player.worldedit_undo.push(undo);
 
+    if ctx.has_flag('s') {
+        let first_pos = direction.offset_pos(pos1, (stack_offset*stack_amt) as i32);
+        let second_pos = direction.offset_pos(pos2, (stack_offset*stack_amt) as i32);
+        ctx.player.worldedit_set_first_position(first_pos);
+        ctx.player.worldedit_set_second_position(second_pos);
+    }
+
     ctx.player.send_worldedit_message(&format!(
         "Your selection was stacked. ({:?})",
         start_time.elapsed()

--- a/crates/core/src/plot/worldedit/mod.rs
+++ b/crates/core/src/plot/worldedit/mod.rs
@@ -571,7 +571,8 @@ static COMMANDS: Lazy<HashMap<&'static str, WorldeditCommand>> = Lazy::new(|| {
             execute_fn: execute_stack,
             description: "Repeat the contents of the selection",
             flags: &[
-                flag!('a', None, "Ignore air blocks")
+                flag!('a', None, "Ignore air blocks"),
+                flag!('s', None, "Shift the selection to the target location"),
             ],
             permission_node: "worldedit.region.stack",
             ..Default::default()


### PR DESCRIPTION
Add -s flag to //stack WorldEdit command to shift the selection to the target location.

This makes repeated stacking way more convenient, and further increases WorldEdit parity.

I've done some minimal testing, and this behaved as expected. The implementation is almost exactly what -s does in the //move command.

Any feedback welcome!
