### PR TITLE
Fix and simplify constant_coalesce pass

### DIFF
--- a/crates/redpiler/src/passes/constant_coalesce.rs
+++ b/crates/redpiler/src/passes/constant_coalesce.rs
@@ -1,59 +1,44 @@
-use std::collections::hash_map::Entry;
-
 use super::Pass;
-use crate::compile_graph::{CompileGraph, CompileNode, NodeIdx, NodeState, NodeType};
+use crate::compile_graph::{CompileGraph, CompileLink, CompileNode, NodeIdx, NodeState, NodeType};
 use crate::{CompilerInput, CompilerOptions};
 use mchprs_world::World;
-use petgraph::unionfind::UnionFind;
-use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeIndexable};
+use petgraph::visit::NodeIndexable;
 use petgraph::Direction;
-use rustc_hash::FxHashMap;
 
 pub struct ConstantCoalesce;
 
 impl<W: World> Pass<W> for ConstantCoalesce {
     fn run_pass(&self, graph: &mut CompileGraph, _: &CompilerOptions, _: &CompilerInput<'_, W>) {
-        let mut vertex_sets = UnionFind::new(graph.node_bound());
-        for edge in graph.edge_references() {
-            let (src, dest) = (edge.source(), edge.target());
-            let node = &graph[src];
-            if node.ty != NodeType::Constant || !node.is_removable() {
-                vertex_sets.union(graph.to_index(src), graph.to_index(dest));
-            }
-        }
+        let constant = graph.add_node(CompileNode {
+            ty: NodeType::Constant,
+            block: None,
+            state: NodeState::ss(15),
+            is_input: false,
+            is_output: false,
+            annotations: Default::default(),
+        });
 
-        let mut constant_nodes = FxHashMap::default();
         for i in 0..graph.node_bound() {
             let idx = NodeIdx::new(i);
             if !graph.contains_node(idx) {
+                continue;
+            }
+            if idx == constant {
                 continue;
             }
             let node = &graph[idx];
             if node.ty != NodeType::Constant || !node.is_removable() {
                 continue;
             }
-            let ss = node.state.output_strength;
+            let output_strength = node.state.output_strength;
 
             let mut neighbors = graph.neighbors_directed(idx, Direction::Outgoing).detach();
             while let Some((edge, dest)) = neighbors.next(graph) {
-                let weight = graph.remove_edge(edge).unwrap();
-                let subgraph_component = vertex_sets.find(graph.to_index(dest));
-
-                let constant_idx = match constant_nodes.entry((subgraph_component, ss)) {
-                    Entry::Occupied(entry) => *entry.get(),
-                    Entry::Vacant(entry) => {
-                        let constant_idx = graph.add_node(CompileNode {
-                            ty: NodeType::Constant,
-                            block: None,
-                            state: NodeState::ss(ss),
-                            is_input: false,
-                            is_output: false,
-                            annotations: Default::default(),
-                        });
-                        *entry.insert(constant_idx)
-                    }
-                };
-                graph.add_edge(constant_idx, dest, weight);
+                let CompileLink { ty, ss } = graph[edge];
+                let ss = ss + 15 - output_strength;
+                if ss < 15 {
+                    graph.add_edge(constant, dest, CompileLink::new(ty, ss));
+                }
             }
             graph.remove_node(idx);
         }


### PR DESCRIPTION
Currently the constant coalesce pass is broken, it crashes the plot both on chungus2 and on mpu8.
This pull request fixes this issue and also simplifies the constant coalesce pass by only having 1 constant node instead of 1 for each signal strength