### PR TITLE
Fix the clippy warnings

### DIFF
--- a/crates/blocks/src/block_entities.rs
+++ b/crates/blocks/src/block_entities.rs
@@ -39,14 +39,13 @@ impl FromStr for ContainerType {
     }
 }
 
-impl ToString for ContainerType {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for ContainerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             ContainerType::Furnace => "minecraft:furnace",
             ContainerType::Barrel => "minecraft:barrel",
             ContainerType::Hopper => "minecraft:hopper",
-        }
-        .to_owned()
+        })
     }
 }
 

--- a/crates/blocks/src/blocks/props.rs
+++ b/crates/blocks/src/blocks/props.rs
@@ -79,12 +79,12 @@ impl FromStr for ComparatorMode {
     }
 }
 
-impl ToString for ComparatorMode {
-    fn to_string(&self) -> String {
-        match self {
-            ComparatorMode::Subtract => "subtract".to_owned(),
-            ComparatorMode::Compare => "compare".to_owned(),
-        }
+impl std::fmt::Display for ComparatorMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ComparatorMode::Subtract => "subtract",
+            ComparatorMode::Compare => "compare",
+        })
     }
 }
 
@@ -145,13 +145,13 @@ impl FromStr for LeverFace {
     }
 }
 
-impl ToString for LeverFace {
-    fn to_string(&self) -> String {
-        match self {
-            LeverFace::Floor => "floor".to_owned(),
-            LeverFace::Ceiling => "ceiling".to_owned(),
-            LeverFace::Wall => "wall".to_owned(),
-        }
+impl std::fmt::Display for LeverFace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            LeverFace::Floor => "floor",
+            LeverFace::Ceiling => "ceiling",
+            LeverFace::Wall => "wall",
+        })
     }
 }
 
@@ -212,13 +212,13 @@ impl FromStr for ButtonFace {
     }
 }
 
-impl ToString for ButtonFace {
-    fn to_string(&self) -> String {
-        match self {
-            ButtonFace::Floor => "floor".to_owned(),
-            ButtonFace::Ceiling => "ceiling".to_owned(),
-            ButtonFace::Wall => "wall".to_owned(),
-        }
+impl std::fmt::Display for ButtonFace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ButtonFace::Floor => "floor",
+            ButtonFace::Ceiling => "ceiling",
+            ButtonFace::Wall => "wall",
+        })
     }
 }
 
@@ -266,13 +266,13 @@ impl FromStr for RedstoneWireSide {
     }
 }
 
-impl ToString for RedstoneWireSide {
-    fn to_string(&self) -> String {
-        match self {
-            RedstoneWireSide::Up => "up".to_owned(),
-            RedstoneWireSide::Side => "side".to_owned(),
-            RedstoneWireSide::None => "none".to_owned(),
-        }
+impl std::fmt::Display for RedstoneWireSide {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            RedstoneWireSide::Up => "up",
+            RedstoneWireSide::Side => "side",
+            RedstoneWireSide::None => "none",
+        })
     }
 }
 
@@ -371,12 +371,12 @@ impl TrapdoorHalf {
     }
 }
 
-impl ToString for TrapdoorHalf {
-    fn to_string(&self) -> String {
-        match self {
-            TrapdoorHalf::Top => "top".to_owned(),
-            TrapdoorHalf::Bottom => "bottom".to_owned(),
-        }
+impl std::fmt::Display for TrapdoorHalf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            TrapdoorHalf::Top => "top",
+            TrapdoorHalf::Bottom => "bottom",
+        })
     }
 }
 
@@ -513,9 +513,9 @@ impl Instrument {
     }
 }
 
-impl ToString for Instrument {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for Instrument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             Instrument::Harp => "harp",
             Instrument::Basedrum => "basedrum",
             Instrument::Snare => "snare",
@@ -538,8 +538,7 @@ impl ToString for Instrument {
             Instrument::Dragon => "dragon",
             Instrument::WitherSkeleton => "wither_skeleton",
             Instrument::Piglin => "piglin",
-        }
-        .to_owned()
+        })
     }
 }
 
@@ -564,6 +563,12 @@ impl FromStr for Instrument {
             "bit" => Instrument::Bit,
             "banjo" => Instrument::Banjo,
             "pling" => Instrument::Pling,
+            "zombie" => Instrument::Zombie,
+            "skeleton" => Instrument::Skeleton,
+            "creeper" => Instrument::Creeper,
+            "dragon" => Instrument::Dragon,
+            "wither_skeleton" => Instrument::WitherSkeleton,
+            "piglin" => Instrument::Piglin,
             _ => return Err(()),
         })
     }

--- a/crates/blocks/src/lib.rs
+++ b/crates/blocks/src/lib.rs
@@ -320,14 +320,14 @@ impl FromStr for BlockDirection {
     }
 }
 
-impl ToString for BlockDirection {
-    fn to_string(&self) -> String {
-        match self {
-            BlockDirection::North => "north".to_owned(),
-            BlockDirection::South => "south".to_owned(),
-            BlockDirection::East => "east".to_owned(),
-            BlockDirection::West => "west".to_owned(),
-        }
+impl std::fmt::Display for BlockDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            BlockDirection::North => "north",
+            BlockDirection::South => "south",
+            BlockDirection::East => "east",
+            BlockDirection::West => "west",
+        })
     }
 }
 
@@ -401,16 +401,16 @@ impl BlockFacing {
     }
 }
 
-impl ToString for BlockFacing {
-    fn to_string(&self) -> String {
-        match self {
-            BlockFacing::North => "north".to_owned(),
-            BlockFacing::South => "south".to_owned(),
-            BlockFacing::East => "east".to_owned(),
-            BlockFacing::West => "west".to_owned(),
-            BlockFacing::Up => "up".to_owned(),
-            BlockFacing::Down => "down".to_owned(),
-        }
+impl std::fmt::Display for BlockFacing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            BlockFacing::North => "north",
+            BlockFacing::South => "south",
+            BlockFacing::East => "east",
+            BlockFacing::West => "west",
+            BlockFacing::Up => "up",
+            BlockFacing::Down => "down",
+        })
     }
 }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -27,7 +27,7 @@ impl_simple_default!(String, i64, bool);
 
 impl<T> ConfigSerializeDefault for Option<T> {
     fn fix_config(self, _: &str, _: &mut DocumentMut) {
-        assert!(matches!(self, None), "`Some` as default is unimplemented");
+        assert!(self.is_none(), "`Some` as default is unimplemented");
     }
 }
 

--- a/crates/core/src/player.rs
+++ b/crates/core/src/player.rs
@@ -417,9 +417,10 @@ impl Player {
 
     /// Sends a raw chat message to the player
     pub fn send_chat_message(&self, message: &[TextComponent]) {
-        let mut component: TextComponent = Default::default();
-        component.extra = message.to_vec();
-        self.send_raw_chat(component);
+        self.send_raw_chat(TextComponent {
+            extra: message.to_vec(),
+            ..Default::default()
+        });
     }
 
     pub fn send_no_permission_message(&self) {
@@ -533,7 +534,7 @@ impl Player {
             window_id: 0,
             state_id: 0,
             slot: slot as i16,
-            slot_data: item.as_ref().map(|item| utils::encode_slot_data(item)),
+            slot_data: item.as_ref().map(utils::encode_slot_data),
         }
         .encode();
         self.client.send_packet(&set_slot);

--- a/crates/core/src/plot/data.rs
+++ b/crates/core/src/plot/data.rs
@@ -51,8 +51,7 @@ static EMPTY_PLOT: Lazy<PlotData> = Lazy::new(|| {
             to_be_ticked: Vec::new(),
             packet_senders: Vec::new(),
         };
-        let chunk_data: Vec<ChunkData> =
-            world.chunks.iter_mut().map(|c| ChunkData::new(c)).collect();
+        let chunk_data: Vec<ChunkData> = world.chunks.iter_mut().map(ChunkData::new).collect();
         PlotData {
             tps: Tps::Limited(10),
             world_send_rate: WorldSendRate::default(),

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -184,10 +184,7 @@ impl World for PlotWorld {
     }
 
     fn get_block_entity(&self, pos: BlockPos) -> Option<&BlockEntity> {
-        let chunk_index = match self.get_chunk_index_for_block(pos.x, pos.z) {
-            Some(idx) => idx,
-            None => return None,
-        };
+        let chunk_index = self.get_chunk_index_for_block(pos.x, pos.z)?;
         let chunk = &self.chunks[chunk_index];
         chunk.get_block_entity(BlockPos::new(pos.x & 0xF, pos.y, pos.z & 0xF))
     }
@@ -521,9 +518,7 @@ impl Plot {
         if let Some(item) = &item_in_hand {
             let has_permission = self.players[player].has_permission("worldedit.selection.pos");
             if item.item_type == (Item::WEWand {}) && has_permission {
-                let same = self.players[player]
-                    .second_position
-                    .map_or(false, |p| p == block_pos);
+                let same = self.players[player].second_position == Some(block_pos);
                 if !same {
                     self.players[player].worldedit_set_second_position(block_pos);
                 }
@@ -695,7 +690,7 @@ impl Plot {
         thread::scope(|s| {
             let handle = s.spawn(|| {
                 self.redpiler
-                    .compile(&mut self.world, bounds, options, ticks, monitor)
+                    .compile(&self.world, bounds, options, ticks, monitor)
             });
             while !handle.is_finished() {
                 // We'll update the players so that they don't time out.
@@ -859,14 +854,13 @@ impl Plot {
                     let player_info = CPlayerInfoUpdate {
                         players: vec![CPlayerInfoUpdatePlayer {
                             uuid: player_join_info.uuid,
-                            actions: {
-                                let mut actions: CPlayerInfoActions = Default::default();
-                                actions.add_player = Some(CPlayerInfoAddPlayer {
+                            actions: CPlayerInfoActions {
+                                add_player: Some(CPlayerInfoAddPlayer {
                                     name: player_join_info.username,
                                     properties: player_join_info.properties,
-                                });
-                                actions.update_gamemode = Some(player_join_info.gamemode.get_id());
-                                actions
+                                }),
+                                update_gamemode: Some(player_join_info.gamemode.get_id()),
+                                ..Default::default()
                             },
                         }],
                     }
@@ -898,10 +892,9 @@ impl Plot {
                     let player_info = CPlayerInfoUpdate {
                         players: vec![CPlayerInfoUpdatePlayer {
                             uuid,
-                            actions: {
-                                let mut actions: CPlayerInfoActions = Default::default();
-                                actions.update_gamemode = Some(gamemode.get_id());
-                                actions
+                            actions: CPlayerInfoActions {
+                                update_gamemode: Some(gamemode.get_id()),
+                                ..Default::default()
                             },
                         }],
                     }
@@ -1186,8 +1179,7 @@ impl Plot {
 
     fn save(&mut self) {
         let world = &mut self.world;
-        let chunk_data: Vec<ChunkData> =
-            world.chunks.iter_mut().map(|c| ChunkData::new(c)).collect();
+        let chunk_data: Vec<ChunkData> = world.chunks.iter_mut().map(ChunkData::new).collect();
         let data = PlotData {
             tps: self.tps,
             world_send_rate: self.world_send_rate,

--- a/crates/core/src/plot/packet_handlers.rs
+++ b/crates/core/src/plot/packet_handlers.rs
@@ -37,7 +37,7 @@ impl ServerBoundPacketHandler for Plot {
         let mut path = PathBuf::from("./schems");
         if CONFIG.schemati {
             let uuid = self.players[player_idx].uuid;
-            path.push(&HyphenatedUUID(uuid).to_string());
+            path.push(HyphenatedUUID(uuid).to_string());
         }
 
         let current = &packet.text[7..];
@@ -53,7 +53,7 @@ impl ServerBoundPacketHandler for Plot {
             Err(err) => {
                 if err.kind() != std::io::ErrorKind::NotFound {
                     error!("There was an error completing //load");
-                    error!("{}", err.to_string());
+                    error!("{}", err);
                 }
                 return;
             }
@@ -93,7 +93,7 @@ impl ServerBoundPacketHandler for Plot {
             let item = ItemStack {
                 count: slot_data.item_count as u8,
                 item_type: Item::from_id(slot_data.item_id as u32),
-                nbt: slot_data.nbt.map(|nbt| nbt::Blob::with_content(nbt)),
+                nbt: slot_data.nbt.map(nbt::Blob::with_content),
             };
             self.players[player].inventory[creative_inventory_action.slot as usize] = Some(item);
             if creative_inventory_action.slot as u32 == self.players[player].selected_slot + 36 {
@@ -104,7 +104,7 @@ impl ServerBoundPacketHandler for Plot {
                         item: self.players[player].inventory
                             [creative_inventory_action.slot as usize]
                             .as_ref()
-                            .map(|item| utils::encode_slot_data(&item)),
+                            .map(utils::encode_slot_data),
                     }],
                 }
                 .encode();
@@ -413,7 +413,7 @@ impl ServerBoundPacketHandler for Plot {
                 slot: 0, // Main hand
                 item: self.players[player].inventory[held_item_change.slot as usize + 36]
                     .as_ref()
-                    .map(|item| utils::encode_slot_data(item)),
+                    .map(utils::encode_slot_data),
             }],
         }
         .encode();

--- a/crates/core/src/plot/worldedit/execute.rs
+++ b/crates/core/src/plot/worldedit/execute.rs
@@ -27,7 +27,7 @@ pub(super) fn execute_wand(ctx: CommandExecuteContext<'_>) {
             slot: 0,
             item: ctx.player.inventory[(ctx.player.selected_slot + 36) as usize]
                 .as_ref()
-                .map(|item| utils::encode_slot_data(&item)),
+                .map(utils::encode_slot_data),
         }],
     }
     .encode();
@@ -996,16 +996,14 @@ pub(super) fn execute_update(ctx: CommandExecuteContext<'_>) {
 
     let (first_pos, second_pos) = if ctx.has_flag('p') {
         ctx.plot.get_corners()
+    } else if let (Some(first_pos), Some(second_pos)) =
+        (ctx.player.first_position, ctx.player.second_position)
+    {
+        (first_pos, second_pos)
     } else {
-        if let (Some(first_pos), Some(second_pos)) =
-            (ctx.player.first_position, ctx.player.second_position)
-        {
-            (first_pos, second_pos)
-        } else {
-            ctx.player
-                .send_error_message("Your selection is incomplete.");
-            return;
-        }
+        ctx.player
+            .send_error_message("Your selection is incomplete.");
+        return;
     };
 
     update(ctx.plot, first_pos, second_pos);

--- a/crates/core/src/plot/worldedit/mod.rs
+++ b/crates/core/src/plot/worldedit/mod.rs
@@ -19,9 +19,9 @@ use rand::Rng;
 use regex::Regex;
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
+use std::fmt;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
-use std::{fmt, i32};
 
 // Attempts to execute a worldedit command. Returns true of the command was handled.
 // The command is not handled if it is not found in the worldedit commands and alias lists.
@@ -404,7 +404,7 @@ struct CommandExecuteContext<'a> {
     flags: Vec<char>,
 }
 
-impl<'a> CommandExecuteContext<'a> {
+impl CommandExecuteContext<'_> {
     fn has_flag(&self, c: char) -> bool {
         self.flags.contains(&c)
     }

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -10,14 +10,17 @@ use std::str::FromStr;
 #[derive(Debug)]
 pub struct HyphenatedUUID(pub u128);
 
-impl ToString for HyphenatedUUID {
-    fn to_string(&self) -> String {
-        let mut hex = format!("{:032x}", self.0);
-        hex.insert(8, '-');
-        hex.insert(13, '-');
-        hex.insert(18, '-');
-        hex.insert(23, '-');
-        hex
+impl std::fmt::Display for HyphenatedUUID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+            self.0 >> 96,
+            (self.0 >> 80) & 0xFFFF,
+            (self.0 >> 64) & 0xFFFF,
+            (self.0 >> 48) & 0xFFFF,
+            self.0 & 0xFFFFFFFFFFFF,
+        )
     }
 }
 
@@ -40,7 +43,7 @@ impl Serialize for HyphenatedUUID {
 
 struct HyphenatedUUIDVisitor;
 
-impl<'de> Visitor<'de> for HyphenatedUUIDVisitor {
+impl Visitor<'_> for HyphenatedUUIDVisitor {
     type Value = HyphenatedUUID;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/network/src/packets/clientbound.rs
+++ b/crates/network/src/packets/clientbound.rs
@@ -12,8 +12,8 @@ pub trait ClientBoundPacket {
 
 fn encode_plugin_message(packet_id: u32, channel: &str, data: &[u8]) -> PacketEncoder {
     let mut buf = Vec::new();
-    buf.write_string(32767, &channel);
-    buf.write_bytes(&data);
+    buf.write_string(32767, channel);
+    buf.write_bytes(data);
     PacketEncoder::new(buf, packet_id)
 }
 
@@ -1033,7 +1033,7 @@ impl ClientBoundPacket for CResetScore {
         buf.write_string(32767, &self.entity_name);
         buf.write_bool(self.objective_name.is_some());
         if let Some(objective_name) = &self.objective_name {
-            buf.write_string(32767, &objective_name);
+            buf.write_string(32767, objective_name);
         }
         PacketEncoder::new(buf, 0x42)
     }
@@ -1214,7 +1214,7 @@ impl ClientBoundPacket for CUpdateScore {
         let mut buf = Vec::new();
         buf.write_string(32767, &self.entity_name);
         buf.write_string(32767, &self.objective_name);
-        buf.write_varint(self.value as i32);
+        buf.write_varint(self.value);
         buf.write_bool(self.display_name.is_some());
         if let Some(display_name) = &self.display_name {
             buf.write_text_component(display_name);

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -360,7 +360,7 @@ impl fmt::Display for DirectBackend {
             }
             let label = match node.ty {
                 NodeType::Repeater { delay, .. } => format!("Repeater({})", delay),
-                NodeType::Torch => format!("Torch"),
+                NodeType::Torch => "Torch".to_string(),
                 NodeType::Comparator { mode, .. } => format!(
                     "Comparator({})",
                     match mode {
@@ -368,14 +368,14 @@ impl fmt::Display for DirectBackend {
                         ComparatorMode::Subtract => "Sub",
                     }
                 ),
-                NodeType::Lamp => format!("Lamp"),
-                NodeType::Button => format!("Button"),
-                NodeType::Lever => format!("Lever"),
-                NodeType::PressurePlate => format!("PressurePlate"),
-                NodeType::Trapdoor => format!("Trapdoor"),
-                NodeType::Wire => format!("Wire"),
+                NodeType::Lamp => "Lamp".to_string(),
+                NodeType::Button => "Button".to_string(),
+                NodeType::Lever => "Lever".to_string(),
+                NodeType::PressurePlate => "PressurePlate".to_string(),
+                NodeType::Trapdoor => "Trapdoor".to_string(),
+                NodeType::Wire => "Wire".to_string(),
                 NodeType::Constant => format!("Constant({})", node.output_power),
-                NodeType::NoteBlock { .. } => format!("NoteBlock"),
+                NodeType::NoteBlock { .. } => "NoteBlock".to_string(),
             };
             let pos = if let Some((pos, _)) = self.blocks[id] {
                 format!("{}, {}, {}", pos.x, pos.y, pos.z)

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -141,7 +141,7 @@ pub struct NonMaxU8(NonZeroU8);
 
 impl NonMaxU8 {
     pub fn new(value: u8) -> Option<Self> {
-        NonZeroU8::new(value + 1).map(|x| Self(x))
+        NonZeroU8::new(value + 1).map(Self)
     }
 
     pub fn get(self) -> u8 {

--- a/crates/redpiler/src/passes/identify_nodes.rs
+++ b/crates/redpiler/src/passes/identify_nodes.rs
@@ -243,10 +243,8 @@ impl NodeAnnotation {
         if !(s.starts_with('[') && s.ends_with(']')) {
             return None;
         }
-        let parts = s[1..s.len() - 1].split(' ').collect_vec();
-        match parts.as_slice() {
-            _ => None,
-        }
+        let _parts = s[1..s.len() - 1].split(' ').collect_vec();
+        None
     }
 
     fn apply(

--- a/crates/redstone/src/wire/turbo.rs
+++ b/crates/redstone/src/wire/turbo.rs
@@ -140,7 +140,7 @@ impl RedstoneWireTurbo {
         let mut neighbors_visited = Vec::with_capacity(24);
         let mut neighbor_nodes = Vec::with_capacity(24);
 
-        for (_i, neighbor_pos) in neighbors[0..24].iter().enumerate() {
+        for neighbor_pos in &neighbors[0..24] {
             let neighbor = if !self.node_cache.contains_key(neighbor_pos) {
                 let node_id = NodeId {
                     index: self.nodes.len(),

--- a/crates/save_data/src/plot_data.rs
+++ b/crates/save_data/src/plot_data.rs
@@ -8,7 +8,7 @@ use mchprs_world::storage::{Chunk, ChunkSection};
 use mchprs_world::TickEntry;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::{fmt, io};
@@ -190,7 +190,7 @@ impl PlotData {
     }
 
     pub fn save_to_file(&self, path: impl AsRef<Path>) -> Result<(), PlotSaveError> {
-        let mut file = OpenOptions::new().write(true).create(true).open(path)?;
+        let mut file = File::create(path)?;
 
         file.write_all(PLOT_MAGIC)?;
         file.write_u32::<LittleEndian>(VERSION)?;

--- a/crates/text/src/lib.rs
+++ b/crates/text/src/lib.rs
@@ -271,8 +271,9 @@ where
     S: Into<String>,
 {
     fn from(value: S) -> Self {
-        let mut tc: TextComponent = Default::default();
-        tc.text = value.into();
-        tc
+        TextComponent {
+            text: value.into(),
+            ..Default::default()
+        }
     }
 }

--- a/crates/world/src/storage.rs
+++ b/crates/world/src/storage.rs
@@ -56,8 +56,7 @@ impl BitBuffer {
     pub fn create(bits_per_entry: u8, entries: usize) -> BitBuffer {
         // 4..9, 15
         let entries_per_long = 64 / bits_per_entry as u64;
-        // Rounding up div
-        let longs_len = (entries + entries_per_long as usize - 1) / entries_per_long as usize;
+        let longs_len = entries.div_ceil(entries_per_long as usize);
         let longs = vec![0; longs_len];
         BitBuffer {
             bits_per_entry: bits_per_entry as u64,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -87,10 +87,7 @@ impl World for TestWorld {
     }
 
     fn get_block_entity(&self, pos: BlockPos) -> Option<&BlockEntity> {
-        let chunk_index = match self.get_chunk_index_for_block(pos.x, pos.z) {
-            Some(idx) => idx,
-            None => return None,
-        };
+        let chunk_index = self.get_chunk_index_for_block(pos.x, pos.z)?;
         let chunk = &self.chunks[chunk_index];
         chunk.get_block_entity(BlockPos::new(pos.x & 0xF, pos.y, pos.z & 0xF))
     }


### PR DESCRIPTION
This fixes all the clippy warnings. I also noticed some instruments were missing in the parser for `mchprs_blocks::blocks::props::Instruments`.

There are two unused code warnings left because I don't want to delete someone else's code. I should also note that there are two failing tests (`comparator_id_test` and `repeater_id_test`) missed by the CI because it doesn't pass the `--workspace` flag when testing. Both of them failed before this commit.