### PR TITLE
Add observers

### DIFF
--- a/crates/blocks/src/blocks/mod.rs
+++ b/crates/blocks/src/blocks/mod.rs
@@ -54,7 +54,6 @@ noop_block_transform!(
     u32,
     bool,
     BlockColorVariant,
-    BlockFacing,
     TrapdoorHalf,
     SignType,
     ButtonFace,
@@ -85,6 +84,33 @@ impl BlockTransform for BlockDirection {
             BlockDirection::East => BlockDirection::South,
             BlockDirection::South => BlockDirection::West,
             BlockDirection::West => BlockDirection::North,
+        }
+    }
+}
+
+impl BlockTransform for BlockFacing {
+    fn rotate90(&mut self) {
+        *self = match self {
+            BlockFacing::North => BlockFacing::East,
+            BlockFacing::East => BlockFacing::South,
+            BlockFacing::South => BlockFacing::West,
+            BlockFacing::West => BlockFacing::North,
+            BlockFacing::Up | BlockFacing::Down => *self,
+        }
+    }
+
+    fn flip(&mut self, dir: FlipDirection) {
+        match dir {
+            FlipDirection::FlipX => match self {
+                BlockFacing::East => *self = BlockFacing::West,
+                BlockFacing::West => *self = BlockFacing::East,
+                _ => {}
+            },
+            FlipDirection::FlipZ => match self {
+                BlockFacing::North => *self = BlockFacing::South,
+                BlockFacing::South => *self = BlockFacing::North,
+                _ => {}
+            },
         }
     }
 }
@@ -743,22 +769,31 @@ blocks! {
         transparent: true,
         cube: true,
     },
-    Observer {
+    RedstoneObserver {
         props: {
-            facing: BlockFacing
+            observer: RedstoneObserver
         },
-        get_id: (facing.get_id() << 1) + 12551,
-        from_id_offset: 12551,
-        from_id(id): 12551..=12561 => {
-            facing: BlockFacing::from_id(id >> 1)
+        get_id: {
+            observer.facing.get_id() * 2
+                + !observer.powered as u32
+                + 12550
+        },
+        from_id_offset: 12550,
+        from_id(id): 12550..=12561 => {
+            observer: {
+                RedstoneObserver::new(
+                    BlockFacing::from_id(id >> 1),
+                    (id & 1) == 0
+                )
+            }
         },
         from_names(_name): {
             "observer" => {
-                facing: Default::default()
+                observer: Default::default()
             }
         },
         get_name: "observer",
-        solid: true,
+        transparent: true,
         cube: true,
     },
     SeaPickle {

--- a/crates/blocks/src/blocks/props.rs
+++ b/crates/blocks/src/blocks/props.rs
@@ -1,5 +1,6 @@
 use super::{Block, BlockDirection, BlockProperty, BlockTransform, FlipDirection};
 use std::str::FromStr;
+use crate::BlockFacing;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, BlockProperty, BlockTransform)]
 pub struct RedstoneRepeater {
@@ -100,6 +101,21 @@ impl RedstoneComparator {
         RedstoneComparator {
             facing,
             mode,
+            powered,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, BlockProperty, BlockTransform)]
+pub struct RedstoneObserver {
+    pub facing: BlockFacing,
+    pub powered: bool
+}
+
+impl RedstoneObserver {
+    pub fn new(facing: BlockFacing, powered: bool) -> RedstoneObserver {
+        RedstoneObserver {
+            facing,
             powered,
         }
     }

--- a/crates/blocks/src/items.rs
+++ b/crates/blocks/src/items.rs
@@ -255,6 +255,12 @@ items! {
         from_id(_id): 658 => {},
         block: true,
     },
+    Observer {
+        props: {},
+        get_id: 665,
+        from_id(_id): 665 => {},
+        block: true,
+    },
     Hopper {
         props: {},
         get_id: 666,

--- a/crates/blocks/src/lib.rs
+++ b/crates/blocks/src/lib.rs
@@ -137,6 +137,18 @@ impl BlockFace {
             _ => panic!("invalid BlockFace with id {}", id),
         }
     }
+
+    pub fn opposite(self) -> BlockFace {
+        use BlockFace::*;
+        match self {
+            Bottom => Top,
+            Top => Bottom,
+            North => South,
+            South => North,
+            West => East,
+            East => West,
+        }
+    }
 }
 
 impl BlockFace {
@@ -397,6 +409,30 @@ impl BlockFacing {
             South => East,
             East => North,
             other => other,
+        }
+    }
+
+    pub fn opposite(self) -> BlockFacing {
+        use BlockFacing::*;
+        match self {
+            North => South,
+            South => North,
+            East => West,
+            West => East,
+            Up => Down,
+            Down => Up,
+        }
+    }
+
+    pub fn block_face(&self) -> BlockFace {
+        use BlockFacing::*;
+        match self {
+            North => BlockFace::North,
+            East => BlockFace::East,
+            South => BlockFace::South,
+            West => BlockFace::West,
+            Up => BlockFace::Top,
+            Down => BlockFace::Bottom,
         }
     }
 }

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -363,8 +363,11 @@ impl Plot {
         let block = self.world.get_block(pos);
         match block {
             Block::StonePressurePlate { .. } => {
-                self.world
-                    .set_block(pos, Block::StonePressurePlate { powered });
+                mchprs_redstone::change_block(
+                    &mut self.world,
+                    pos,
+                    Block::StonePressurePlate { powered }
+                );
                 mchprs_redstone::update_surrounding_blocks(&mut self.world, pos);
                 mchprs_redstone::update_surrounding_blocks(
                     &mut self.world,

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -47,10 +47,7 @@ fn compile_node(
         match weight.ty {
             LinkType::Default => {
                 if default_input_count >= MAX_INPUTS {
-                    panic!(
-                        "Exceeded the maximum number of default inputs {}",
-                        MAX_INPUTS
-                    );
+                    panic!("Exceeded the maximum number of default inputs {}", MAX_INPUTS);
                 }
                 default_input_count += 1;
                 default_inputs.ss_counts[ss as usize] += 1;
@@ -109,6 +106,7 @@ fn compile_node(
             far_input: far_input.map(|value| NonMaxU8::new(value).unwrap()),
             facing_diode: *facing_diode,
         },
+        CNodeType::Observer => NodeType::Observer,
         CNodeType::Lamp => NodeType::Lamp,
         CNodeType::Button => NodeType::Button,
         CNodeType::Lever => NodeType::Lever,

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -118,6 +118,7 @@ pub enum NodeType {
         far_input: Option<NonMaxU8>,
         facing_diode: bool,
     },
+    Observer,
     Lamp,
     Button,
     Lever,

--- a/crates/redpiler/src/backend/direct/update.rs
+++ b/crates/redpiler/src/backend/direct/update.rs
@@ -3,105 +3,111 @@ use mchprs_world::TickPriority;
 use super::node::{NodeId, NodeType};
 use super::*;
 
-#[inline(always)]
-pub(super) fn update_node(
-    scheduler: &mut TickScheduler,
-    events: &mut Vec<Event>,
-    nodes: &mut Nodes,
-    node_id: NodeId,
-) {
-    let node = &mut nodes[node_id];
+impl DirectBackend {
+    #[inline(always)]
+    pub fn update_node(&mut self, node_id: NodeId) {
+        let node = &mut self.nodes[node_id];
 
-    match node.ty {
-        NodeType::Repeater {
-            delay,
-            facing_diode,
-        } => {
-            let should_be_locked = get_bool_side(node);
-            if should_be_locked != node.locked {
-                set_node_locked(node, should_be_locked);
-            }
-            if node.locked || node.pending_tick {
-                return;
-            }
+        match node.ty {
+            NodeType::Repeater {
+                delay,
+                facing_diode,
+            } => {
+                let should_be_locked = get_bool_side(node);
+                if should_be_locked != node.locked {
+                    self.set_node_locked(node_id, should_be_locked);
+                }
+                let node = &mut self.nodes[node_id];
+                if node.locked || node.pending_tick {
+                    return;
+                }
 
-            let should_be_powered = get_bool_input(node);
-            if should_be_powered != node.powered {
-                let priority = if facing_diode {
-                    TickPriority::Highest
-                } else if !should_be_powered {
-                    TickPriority::Higher
-                } else {
-                    TickPriority::High
-                };
-                schedule_tick(scheduler, node_id, node, delay as usize, priority);
-            }
-        }
-        NodeType::Torch => {
-            if node.pending_tick {
-                return;
-            }
-            let should_be_powered = !get_bool_input(node);
-            if node.powered != should_be_powered {
-                schedule_tick(scheduler, node_id, node, 1, TickPriority::Normal);
-            }
-        }
-        NodeType::Comparator {
-            mode,
-            far_input,
-            facing_diode,
-        } => {
-            if node.pending_tick {
-                return;
-            }
-            let (mut input_power, side_input_power) = get_all_input(node);
-            if let Some(far_override) = far_input {
-                if input_power < 15 {
-                    input_power = far_override.get();
+                let should_be_powered = get_bool_input(node);
+                if should_be_powered != node.powered {
+                    let priority = if facing_diode {
+                        TickPriority::Highest
+                    } else if !should_be_powered {
+                        TickPriority::Higher
+                    } else {
+                        TickPriority::High
+                    };
+                    schedule_tick(&mut self.scheduler, node_id, node, delay as usize, priority);
                 }
             }
-            let old_strength = node.output_power;
-            let output_power = calculate_comparator_output(mode, input_power, side_input_power);
-            if output_power != old_strength {
-                let priority = if facing_diode {
-                    TickPriority::High
-                } else {
-                    TickPriority::Normal
-                };
-                schedule_tick(scheduler, node_id, node, 1, priority);
-            }
-        }
-        NodeType::Lamp => {
-            let should_be_lit = get_bool_input(node);
-            let lit = node.powered;
-            if lit && !should_be_lit {
-                schedule_tick(scheduler, node_id, node, 2, TickPriority::Normal);
-            } else if !lit && should_be_lit {
-                set_node(node, true);
-            }
-        }
-        NodeType::Trapdoor => {
-            let should_be_powered = get_bool_input(node);
-            if node.powered != should_be_powered {
-                set_node(node, should_be_powered);
-            }
-        }
-        NodeType::Wire => {
-            let (input_power, _) = get_all_input(node);
-            if node.output_power != input_power {
-                node.output_power = input_power;
-                node.changed = true;
-            }
-        }
-        NodeType::NoteBlock { noteblock_id } => {
-            let should_be_powered = get_bool_input(node);
-            if node.powered != should_be_powered {
-                set_node(node, should_be_powered);
-                if should_be_powered {
-                    events.push(Event::NoteBlockPlay { noteblock_id });
+            NodeType::Torch => {
+                if node.pending_tick {
+                    return;
+                }
+                let should_be_powered = !get_bool_input(node);
+                if node.powered != should_be_powered {
+                    schedule_tick(&mut self.scheduler, node_id, node, 1, TickPriority::Normal);
                 }
             }
+            NodeType::Comparator {
+                mode,
+                far_input,
+                facing_diode,
+            } => {
+                if node.pending_tick {
+                    return;
+                }
+                let (mut input_power, side_input_power) = get_all_input(node);
+                if let Some(far_override) = far_input {
+                    if input_power < 15 {
+                        input_power = far_override.get();
+                    }
+                }
+                let old_strength = node.output_power;
+                let output_power = calculate_comparator_output(mode, input_power, side_input_power);
+                if output_power != old_strength {
+                    let priority = if facing_diode {
+                        TickPriority::High
+                    } else {
+                        TickPriority::Normal
+                    };
+                    schedule_tick(&mut self.scheduler, node_id, node, 1, priority);
+                }
+            }
+            NodeType::Observer => {
+                if node.pending_tick {
+                    return;
+                }
+                if !node.powered {
+                    schedule_tick(&mut self.scheduler, node_id, node, 1, TickPriority::Higher);
+                }
+            }
+            NodeType::Lamp => {
+                let should_be_lit = get_bool_input(node);
+                let lit = node.powered;
+                if lit && !should_be_lit {
+                    schedule_tick(&mut self.scheduler, node_id, node, 2, TickPriority::Normal);
+                } else if !lit && should_be_lit {
+                    self.set_node_powered(node_id, true);
+                }
+            }
+            NodeType::Trapdoor => {
+                let should_be_powered = get_bool_input(node);
+                if node.powered != should_be_powered {
+                    self.set_node_powered(node_id, should_be_powered);
+                }
+            }
+            NodeType::Wire => {
+                let (input_power, _) = get_all_input(node);
+                if node.output_power != input_power {
+                    node.output_power = input_power;
+                    node.changed = true;
+                }
+            }
+            NodeType::NoteBlock { noteblock_id } => {
+                let should_be_powered = get_bool_input(node);
+                if node.powered != should_be_powered {
+                    self.set_node_powered(node_id, should_be_powered);
+                    if should_be_powered {
+                        self.events.push(Event::NoteBlockPlay { noteblock_id });
+                    }
+                }
+            }
+            _ => {} // unreachable!("Node {:?} should not be updated!", node.ty),
         }
-        _ => {} // unreachable!("Node {:?} should not be updated!", node.ty),
     }
 }

--- a/crates/redpiler/src/backend/mod.rs
+++ b/crates/redpiler/src/backend/mod.rs
@@ -28,6 +28,7 @@ pub trait JITBackend {
 
     fn on_use_block(&mut self, pos: BlockPos);
     fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool);
+    fn on_observe_trigger(&mut self, pos: BlockPos);
     fn flush<W: World>(&mut self, world: &mut W, io_only: bool);
     fn reset<W: World>(&mut self, world: &mut W, io_only: bool);
     fn has_pending_ticks(&self) -> bool;

--- a/crates/redpiler/src/compile_graph.rs
+++ b/crates/redpiler/src/compile_graph.rs
@@ -16,6 +16,7 @@ pub enum NodeType {
         far_input: Option<u8>,
         facing_diode: bool,
     },
+    Observer,
     Lamp,
     Button,
     Lever,

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -22,6 +22,7 @@ fn block_powered_mut(block: &mut Block) -> Option<&mut bool> {
         Block::RedstoneTorch { lit } => lit,
         Block::RedstoneWallTorch { lit, .. } => lit,
         Block::RedstoneRepeater { repeater } => &mut repeater.powered,
+        Block::RedstoneObserver { observer } => &mut observer.powered,
         Block::Lever { lever } => &mut lever.powered,
         Block::StoneButton { button } => &mut button.powered,
         Block::StonePressurePlate { powered } => powered,
@@ -214,6 +215,10 @@ impl Compiler {
 
     pub fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool) {
         self.backend().set_pressure_plate(pos, powered);
+    }
+
+    pub fn on_observe_trigger(&mut self, pos: BlockPos) {
+        self.backend().on_observe_trigger(pos);
     }
 
     pub fn flush<W: World>(&mut self, world: &mut W) {

--- a/crates/redpiler/src/passes/constant_fold.rs
+++ b/crates/redpiler/src/passes/constant_fold.rs
@@ -98,6 +98,10 @@ fn fold(graph: &mut CompileGraph) -> usize {
                     15
                 }
             }
+            NodeType::Observer => {
+                // Observed power is constant, observer will never output a signal
+                0
+            }
             _ => continue,
         };
 

--- a/crates/redpiler/src/passes/export_graph.rs
+++ b/crates/redpiler/src/passes/export_graph.rs
@@ -58,6 +58,7 @@ fn convert_node(
                 CComparatorMode::Compare => ComparatorMode::Compare,
                 CComparatorMode::Subtract => ComparatorMode::Subtract,
             }),
+            CNodeType::Observer => NodeType::Observer,
             CNodeType::Lamp => NodeType::Lamp,
             CNodeType::Button => NodeType::Button,
             CNodeType::Lever => NodeType::Lever,

--- a/crates/redpiler/src/passes/identify_nodes.rs
+++ b/crates/redpiler/src/passes/identify_nodes.rs
@@ -144,6 +144,9 @@ fn identify_block<W: World>(
                 },
             ),
         ),
+        Block::RedstoneObserver { observer } => {
+            (NodeType::Observer, NodeState::simple(observer.powered))
+        },
         Block::RedstoneTorch { lit, .. } | Block::RedstoneWallTorch { lit, .. } => {
             (NodeType::Torch, NodeState::simple(lit))
         }

--- a/crates/redpiler_graph/src/lib.rs
+++ b/crates/redpiler_graph/src/lib.rs
@@ -34,6 +34,7 @@ pub enum NodeType {
     Repeater(u8),
     Torch,
     Comparator(ComparatorMode),
+    Observer,
     Lamp,
     Button,
     Lever,

--- a/crates/redstone/src/comparator.rs
+++ b/crates/redstone/src/comparator.rs
@@ -182,10 +182,10 @@ pub fn tick(mut comp: RedstoneComparator, world: &mut impl World, pos: BlockPos)
         let powered = comp.powered;
         if powered && !should_be_powered {
             comp.powered = false;
-            world.set_block(pos, Block::RedstoneComparator { comparator: comp });
+            super::change_block(world, pos, Block::RedstoneComparator { comparator: comp });
         } else if !powered && should_be_powered {
             comp.powered = true;
-            world.set_block(pos, Block::RedstoneComparator { comparator: comp });
+            super::change_block(world, pos, Block::RedstoneComparator { comparator: comp });
         }
         on_state_change(comp, world, pos);
     }

--- a/crates/redstone/src/observer.rs
+++ b/crates/redstone/src/observer.rs
@@ -1,0 +1,43 @@
+use crate::change_block;
+use mchprs_blocks::blocks::{Block, RedstoneObserver};
+use mchprs_blocks::{BlockFace, BlockPos};
+use mchprs_world::{TickPriority, World};
+
+pub fn on_neighbour_changed(
+    obs: RedstoneObserver,
+    world: &mut impl World,
+    pos: BlockPos,
+    source_face: BlockFace
+) {
+    if source_face == obs.facing.block_face() && !world.pending_tick_at(pos) {
+        if !obs.powered {
+            world.schedule_tick(pos, 1, TickPriority::Higher);
+        }
+    }
+}
+
+// This is (more or less) the same as it is in the RedstoneRepeater struct.
+// Sometime in the future, this needs to be reused. LLVM might optimize
+// it way, but te human brane wil not!
+fn on_state_change(obs: RedstoneObserver, world: &mut impl World, pos: BlockPos) {
+    let back_pos = pos.offset(obs.facing.opposite().block_face());
+    let back_block = world.get_block(back_pos);
+    super::update(back_block, world, back_pos);
+    for direction in &BlockFace::values() {
+        let neighbor_pos = back_pos.offset(*direction);
+        let block = world.get_block(neighbor_pos);
+        super::update(block, world, neighbor_pos);
+    }
+}
+
+pub fn tick(mut obs: RedstoneObserver, world: &mut impl World, pos: BlockPos) {
+    if obs.powered {
+        obs.powered = false;
+        change_block(world, pos, Block::RedstoneObserver { observer: obs });
+    } else {
+        obs.powered = true;
+        change_block(world, pos, Block::RedstoneObserver { observer: obs });
+        world.schedule_tick(pos, 1, TickPriority::Normal);
+    }
+    on_state_change(obs, world, pos);
+}

--- a/crates/redstone/src/repeater.rs
+++ b/crates/redstone/src/repeater.rs
@@ -1,6 +1,7 @@
 use mchprs_blocks::blocks::{Block, RedstoneRepeater};
 use mchprs_blocks::{BlockDirection, BlockFace, BlockPos};
 use mchprs_world::{TickPriority, World};
+use crate::change_block;
 
 pub fn get_state_for_placement(
     world: &impl World,
@@ -67,10 +68,10 @@ pub fn on_neighbor_updated(mut rep: RedstoneRepeater, world: &mut impl World, po
     let should_be_locked = should_be_locked(rep.facing, world, pos);
     if !rep.locked && should_be_locked {
         rep.locked = true;
-        world.set_block(pos, Block::RedstoneRepeater { repeater: rep });
+        change_block(world, pos, Block::RedstoneRepeater { repeater: rep });
     } else if rep.locked && !should_be_locked {
         rep.locked = false;
-        world.set_block(pos, Block::RedstoneRepeater { repeater: rep });
+        change_block(world, pos, Block::RedstoneRepeater { repeater: rep });
     }
 
     if !rep.locked && !world.pending_tick_at(pos) {
@@ -89,14 +90,14 @@ pub fn tick(mut rep: RedstoneRepeater, world: &mut impl World, pos: BlockPos) {
     let should_be_powered = should_be_powered(rep, world, pos);
     if rep.powered && !should_be_powered {
         rep.powered = false;
-        world.set_block(pos, Block::RedstoneRepeater { repeater: rep });
+        change_block(world, pos, Block::RedstoneRepeater { repeater: rep });
         on_state_change(rep, world, pos);
     } else if !rep.powered {
         if !should_be_powered {
             world.schedule_tick(pos, rep.delay as u32, TickPriority::Higher);
         }
         rep.powered = true;
-        world.set_block(pos, Block::RedstoneRepeater { repeater: rep });
+        change_block(world, pos, Block::RedstoneRepeater { repeater: rep });
         on_state_change(rep, world, pos);
     }
 }

--- a/crates/redstone/src/wire/mod.rs
+++ b/crates/redstone/src/wire/mod.rs
@@ -4,6 +4,7 @@ use mchprs_blocks::blocks::{Block, RedstoneWire, RedstoneWireSide};
 use mchprs_blocks::{BlockDirection, BlockFace, BlockPos};
 use mchprs_world::World;
 use turbo::RedstoneWireTurbo;
+use crate::change_block;
 
 pub fn make_cross(power: u8) -> RedstoneWire {
     RedstoneWire {
@@ -77,7 +78,7 @@ pub fn on_neighbor_updated(mut wire: RedstoneWire, world: &mut impl World, pos: 
 
     if wire.power != new_power {
         wire.power = new_power;
-        world.set_block(pos, Block::RedstoneWire { wire });
+        change_block(world, pos, Block::RedstoneWire { wire });
         RedstoneWireTurbo::update_surrounding_neighbors(world, pos);
     }
 }
@@ -115,7 +116,7 @@ fn can_connect_to(block: Block, side: BlockDirection) -> bool {
         Block::RedstoneRepeater { repeater } => {
             repeater.facing == side || repeater.facing == side.opposite()
         }
-        Block::Observer { facing } => facing == side.block_facing(),
+        Block::RedstoneObserver { observer } => observer.facing == side.block_facing(),
         _ => false,
     }
 }

--- a/crates/redstone/src/wire/turbo.rs
+++ b/crates/redstone/src/wire/turbo.rs
@@ -6,6 +6,7 @@ use mchprs_blocks::blocks::{Block, RedstoneWire};
 use mchprs_blocks::{BlockFace, BlockPos};
 use mchprs_world::World;
 use rustc_hash::FxHashMap;
+use crate::change_block;
 
 fn unwrap_wire(block: Block) -> RedstoneWire {
     match block {
@@ -389,7 +390,7 @@ impl RedstoneWireTurbo {
         }
         if i != j {
             wire.power = j;
-            world.set_block(pos, Block::RedstoneWire { wire });
+            change_block(world, pos, Block::RedstoneWire { wire });
         }
         wire
     }

--- a/tests/components.rs
+++ b/tests/components.rs
@@ -1,8 +1,8 @@
 mod common;
 use common::*;
 
-use mchprs_blocks::blocks::Block;
-use mchprs_blocks::BlockDirection;
+use mchprs_blocks::blocks::{Block, RedstoneObserver};
+use mchprs_blocks::{BlockDirection, BlockFacing};
 use mchprs_world::World;
 
 test_all_backends!(lever_on_off);
@@ -181,4 +181,73 @@ fn wire_no_reach(backend: TestBackend) {
     runner.check_block_powered(trapdoor_pos, false);
     runner.use_block(lever_pos);
     runner.check_block_powered(trapdoor_pos, false);
+}
+
+test_all_backends!(observer_on_off);
+fn observer_on_off(backend: TestBackend) {
+    let lever_pos = pos(0, 1, 0);
+    let observer_pos = pos(1, 1, 0);
+    let output_pos = pos(2, 1, 0);
+
+    let mut world = TestWorld::new(1);
+    make_lever(&mut world, lever_pos);
+    world.set_block(
+        observer_pos,
+        Block::RedstoneObserver {
+            observer: RedstoneObserver {
+                facing: BlockFacing::West,
+                powered: false
+            }
+        }
+    );
+    make_wire(&mut world, output_pos);
+
+    let mut runner = BackendRunner::new(world, backend);
+    runner.check_block_powered(observer_pos, false);
+    runner.check_block_powered(output_pos, false);
+    runner.use_block(lever_pos);
+    runner.check_block_powered(observer_pos, false);
+    runner.check_block_powered(output_pos, false);
+    runner.tick();
+    runner.check_block_powered(observer_pos, true);
+    runner.check_block_powered(output_pos, true);
+    runner.tick();
+    runner.check_block_powered(observer_pos, false);
+    runner.check_block_powered(output_pos, false);
+}
+
+test_all_backends!(observer_repeater_lock);
+fn observer_repeater_lock(backend: TestBackend) {
+    let repeater_pos_1 = pos(0, 1, 1);
+    let lever_pos_1 = pos(0, 1, 0);
+    let repeater_pos_2 = pos(1, 1, 1);
+    let lever_pos_2 = pos(2, 1, 1);
+    let observer_pos = pos(0, 2, 1);
+
+    let mut world = TestWorld::new(1);
+    make_repeater(&mut world, repeater_pos_1, 1, BlockDirection::North);
+    make_lever(&mut world, lever_pos_1);
+    make_repeater(&mut world, repeater_pos_2, 1, BlockDirection::East);
+    make_lever(&mut world, lever_pos_2);
+    world.set_block(
+        observer_pos,
+        Block::RedstoneObserver {
+            observer: RedstoneObserver {
+                facing: BlockFacing::Down,
+                powered: false
+            }
+        }
+    );
+
+    let mut runner = BackendRunner::new(world, backend);
+    runner.use_block(lever_pos_2);
+    runner.check_block_powered(observer_pos, false);
+    runner.tick();
+    runner.check_block_powered(observer_pos, false);
+    runner.tick();
+    runner.check_block_powered(observer_pos, true);
+    runner.tick();
+    runner.check_block_powered(observer_pos, false);
+    runner.use_block(lever_pos_1); // Should not yield an update since the repeater is now locked
+    runner.check_powered_for(observer_pos, false, 5);
 }


### PR DESCRIPTION
I was messing around with observers and thought this could also be useful for the base project.

This PR implements observer functionality for both redpiler and the base redstone backend, closing #73. It also includes a bunch of observer related tests. I am fairly sure the observer implementation is accurate and exactly matches vanilla.

The changes to block updates may slightly negatively impact performance, especially when not using redpiler. However, it is just a simple loop to check for adjacent blocks when a block is updated, so I imagine it is fine.
When using redpiler, performance should be nearly identical, the only change being that node updates are now also done for repeater locking and output blocks (e.g. lamps turning on or trapdoors changing state).

Also, Redpiler will now only update nodes when their *maximum* input signal strength has changed, since no node actually uses any signal strength below the max. (This change was needed for observers to work correctly, but I implemented it for every node.)