### PR TITLE
Add aarch64-pc-windows-msvc and aarch64-unknown-linux-gnu target to build.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
           - aarch64-pc-windows-msvc
           - x86_64-apple-darwin
@@ -20,6 +21,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: .exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,16 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
           - x86_64-apple-darwin
           - aarch64-apple-darwin
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            ext: .exe
+          - target: aarch64-pc-windows-msvc
             os: windows-latest
             ext: .exe
           - target: x86_64-apple-darwin
@@ -43,6 +47,8 @@ jobs:
       - name: Build
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld.exe
+          CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER: rust-lld.exe
+
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload artifact


### PR DESCRIPTION
This should close issue #199
Ideally I would have also included linux on arm builds here, but github doesn't really have arm runners and cross compiling openssl is more annoying than I had the patience for, so we can just add that when someone does.