### PR TITLE
Add worldsendrate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ server_context = "global"
 | `/speed [speed]` | None | Sets your flyspeed. |
 | `/gamemode [mode]` | `/gmc`, `/gmsp` | Sets your gamemode. |
 | `/container [type] [power]` | None | Gives you a container (e.g. barrel) which outputs a specified amount of power when used with a comparator. |
+| `/worldsendrate <hertz>` | `/wsr` | Sets the world send rate to `<hertz>` (frequency of world updates sent to clients). Range: 1-1000. Default: 60. |
 | `/toggleautorp` | None | Toggles automatic redpiler compilation. |
 | `/stop` | None | Stops the server. |
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ server_context = "global"
 ### General Commands
 | Command | Alias | Description |
 | --- | --- |--- |
-| `/rtps [rtps\|unlimited]` | None | Set the **redstone** ticks per second in the plot to `[rtps]`. (There are two game ticks in a redstone tick) |
-| `/radvance [ticks]` | `/radv` | Advances the plot by `[ticks]` redstone ticks. |
-| `/teleport [player]` | `/tp` | Teleports you to `[player]`. |
-| `/teleport [x] [y] [z]` | `/tp` | Teleports you to `[x] [y] [z]`. Supports relative coordinates. Floats can be expressed as described [here](https://doc.rust-lang.org/std/primitive.f64.html#grammar). |
-| `/speed [speed]` | None | Sets your flyspeed. |
-| `/gamemode [mode]` | `/gmc`, `/gmsp` | Sets your gamemode. |
-| `/container [type] [power]` | None | Gives you a container (e.g. barrel) which outputs a specified amount of power when used with a comparator. |
+| `/rtps [rtps\|unlimited]` | None | Set the **redstone** ticks per second in the plot to `[rtps]` or `unlimited`. Default: 10. (There are two game ticks in a redstone tick) |
+| `/radvance <ticks>` | `/radv` | Advances the plot by `<ticks>` redstone ticks. |
+| `/teleport <player>` | `/tp` | Teleports you to `<player>`. |
+| `/teleport <x> <y> <z>` | `/tp` | Teleports you to `<x> <y> <z>`. Supports relative coordinates. Floats can be expressed as described [here](https://doc.rust-lang.org/std/primitive.f64.html#grammar). |
+| `/speed <speed>` | None | Sets your flyspeed. |
+| `/gamemode <mode>` | `/gmc`, `/gmsp` | Sets your gamemode. |
+| `/container <type> <power>` | None | Gives you a container (e.g. barrel) which outputs a specified amount of power when used with a comparator. |
 | `/worldsendrate [hertz]` | `/wsr` | Sets the world send rate to `[hertz]` (frequency of world updates sent to clients). Range: 1-1000. Default: 60. |
 | `/toggleautorp` | None | Toggles automatic redpiler compilation. |
 | `/stop` | None | Stops the server. |
@@ -115,8 +115,8 @@ These are the commands that are currently implemented:
 | `/plot claim` | `/p c` | Claims the plot you are in if it is not already claimed. |
 | `/plot auto` | `/p a` | Automatically finds an unclaimed plot and claims. |
 | `/plot middle` | None | Teleports you to the center of the plot you are in. |
-| `/plot visit [player]` | `/p v` | Teleports you to a player's plot. |
-| `/plot tp [x] [z]` | None | Teleports you to the plot at `[x] [y]`. Supports relative coordinates. |
+| `/plot visit <player> [index]` | `/p v` | Teleports you to a player's plot. |
+| `/plot tp <x> <z>` | None | Teleports you to the plot at `<x> <z>`. Supports relative coordinates. |
 | `/plot lock` | None | Locks the player into the plot so moving outside of the plot bounds does not transfer you to other plots. |
 | `/plot unlock` | None | Reverses the locking done by `/plot lock`. |
 | `/plot select` | `/p sel` | Uses WorldEdit to select the entire plot. |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ server_context = "global"
 | `/speed [speed]` | None | Sets your flyspeed. |
 | `/gamemode [mode]` | `/gmc`, `/gmsp` | Sets your gamemode. |
 | `/container [type] [power]` | None | Gives you a container (e.g. barrel) which outputs a specified amount of power when used with a comparator. |
-| `/worldsendrate <hertz>` | `/wsr` | Sets the world send rate to `<hertz>` (frequency of world updates sent to clients). Range: 1-1000. Default: 60. |
+| `/worldsendrate [hertz]` | `/wsr` | Sets the world send rate to `[hertz]` (frequency of world updates sent to clients). Range: 1-1000. Default: 60. |
 | `/toggleautorp` | None | Toggles automatic redpiler compilation. |
 | `/stop` | None | Stops the server. |
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Placing or breaking blocks while redpiler is running will cause a reset and disa
 | `--update` | `-u` | Update all blocks after redpiler resets. |
 | `--export` | `-e` | Export the compile graph using a binary format. This can be useful for developing out-of-tree uses of redpiler graphs. |
 | `--export-dot` | None | Create a graphvis dot file of backend graph. Used for debugging/development. |
+| `--print-after-all` | None | Print out the RIL circuit after every redpiler pass. Used for debugging/development. |
+| `--print-before-backend` | None | Print out the RIL circuit before starting backend compilation. Used for debugging/development. |
 
 ## Acknowledgments
 - [@AL1L](https://github.com/AL1L) for his contributions to worldedit and other various features.

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -488,8 +488,16 @@ impl Plot {
                 self.players[player].set_inventory_slot(slot, Some(item));
             }
             "worldsendrate" | "wsr" => {
+                if args.is_empty() {
+                    self.players[player].send_system_message(&format!(
+                        "Current world send rate: {} Hz",
+                        self.world_send_rate.0
+                    ));
+                    return false;
+                }
+
                 if args.len() != 1 {
-                    self.players[player].send_error_message("Usage: /worldsendrate <hertz>");
+                    self.players[player].send_error_message("Usage: /worldsendrate [hertz]");
                     return false;
                 }
 
@@ -984,7 +992,7 @@ pub static DECLARE_COMMANDS: Lazy<PacketEncoder> = Lazy::new(|| {
             },
             // 49: /worldsendrate
             Node {
-                flags: (CommandFlags::LITERAL).bits() as i8,
+                flags: (CommandFlags::LITERAL | CommandFlags::EXECUTABLE).bits() as i8,
                 children: vec![50],
                 redirect_node: None,
                 name: Some("worldsendrate"),


### PR DESCRIPTION
Fixes #186 by adding documentation for the `/worldsendrate` command.
I must have forgotten to add it back when I added this feature.
This PR also adjusts the bracket notation to use the more conventional `[optional]` vs. `<required>` style.
While I was at it I also documented the new redpiler compile flags.