### PR TITLE
Fix sound id off-by-one error in sound effect packet

### DIFF
--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -244,7 +244,7 @@ impl World for PlotWorld {
         // players A notchian server would only send to players in hearing distance
         // (volume.clamp(0.0, 1.0) * 16.0)
         let sound_effect_data = CSoundEffect {
-            sound_id,
+            sound_id: sound_id + 1,
             sound_name: None,
             has_fixed_range: None,
             range: None,


### PR DESCRIPTION
This PR fixes the issue outlined in #158.
During the update to 1.20.4 we introduced an off-by-one error in the usage of the sound effect packet, which now has the id 0 reserved and therefore pushes all sound ids back by one.
See: https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol?oldid=2773281#Sound_Effect
