### PR TITLE
Allow redstone ticks per second and world send rate to be fractional

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ server_context = "global"
 ### General Commands
 | Command                     | Alias           | Description                                                                                                                                                           |
 |-----------------------------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `/rtps [rtps\|unlimited]`   | None            | Set the **redstone** ticks per second in the plot to `[rtps]` or `unlimited`. Default: 10. (There are two game ticks in a redstone tick)                              |
+| `/rtps [rtps\|unlimited]`   | None            | Set redstone ticks/s (fractional or `unlimited`). Default: 10. There are two game ticks per redstone tick.                                                            |
 | `/radvance <ticks>`         | `/radv`         | Advances the plot by `<ticks>` redstone ticks.                                                                                                                        |
 | `/teleport <player>`        | `/tp`           | Teleports you to `<player>`.                                                                                                                                          |
 | `/teleport <x> <y> <z>`     | `/tp`           | Teleports you to `<x> <y> <z>`. Supports relative coordinates. Floats can be expressed as described [here](https://doc.rust-lang.org/std/primitive.f64.html#grammar). |
 | `/speed <speed>`            | None            | Sets your flyspeed.                                                                                                                                                   |
 | `/gamemode <mode>`          | `/gmc`, `/gmsp` | Sets your gamemode.                                                                                                                                                   |
 | `/container <type> <power>` | None            | Gives you a container (e.g. barrel) which outputs a specified amount of power when used with a comparator.                                                            |
-| `/worldsendrate [hertz]`    | `/wsr`          | Sets the world send rate to `[hertz]` (frequency of world updates sent to clients). Range: 1-1000. Default: 60.                                                       |
+| `/worldsendrate [hertz]`    | `/wsr`          | World updates/s (0-1000, fractional; 0 disables periodic sends). Default: 60.                                                                                         |
 | `/toggleautorp`             | None            | Toggles automatic redpiler compilation.                                                                                                                               |
 | `/stop`                     | None            | Stops the server.                                                                                                                                                     |
 

--- a/crates/core/src/plot/commands.rs
+++ b/crates/core/src/plot/commands.rs
@@ -187,6 +187,7 @@ impl Plot {
 
                 self.reset_redpiler();
                 self.start_redpiler(options);
+                self.publish_world();
 
                 debug!("Compile took {:?}", start_time.elapsed());
             }
@@ -207,6 +208,7 @@ impl Plot {
             }
             "reset" | "r" => {
                 self.reset_redpiler();
+                self.publish_world();
             }
             _ => self.players[player].send_error_message("Invalid argument for /redpiler"),
         }
@@ -293,7 +295,15 @@ impl Plot {
                     return false;
                 }
 
-                let tps = if let Ok(tps) = args[0].parse::<u32>() {
+                let tps = if let Ok(tps) = args[0].parse::<f32>() {
+                    if !tps.is_finite() {
+                        self.players[player].send_error_message("RTPS must be a finite number!");
+                        return false;
+                    }
+                    if tps < 0.0 {
+                        self.players[player].send_error_message("RTPS cannot be negative!");
+                        return false;
+                    }
                     Tps::Limited(tps)
                 } else if !args[0].is_empty() && "unlimited".starts_with(args[0]) {
                     Tps::Unlimited
@@ -322,10 +332,7 @@ impl Plot {
                 };
                 let start_time = Instant::now();
                 self.tickn(ticks as u64);
-
-                if self.redpiler.is_active() {
-                    self.redpiler.flush(&mut self.world);
-                }
+                self.publish_world();
                 self.players[player].send_system_message(&format!(
                     "Plot has been advanced by {} ticks ({:?})",
                     ticks,
@@ -491,7 +498,7 @@ impl Plot {
                 if args.is_empty() {
                     self.players[player].send_system_message(&format!(
                         "Current world send rate: {} Hz",
-                        self.world_send_rate.0
+                        self.world.world_send_rate.0
                     ));
                     return false;
                 }
@@ -501,22 +508,29 @@ impl Plot {
                     return false;
                 }
 
-                let Ok(hertz) = args[0].parse::<u32>() else {
+                let Ok(hertz) = args[0].parse::<f32>() else {
                     self.players[player].send_error_message("Unable to parse send rate!");
                     return false;
                 };
-                if hertz == 0 {
-                    self.players[player].send_error_message("The world send rate cannot be 0!");
+                if !hertz.is_finite() {
+                    self.players[player]
+                        .send_error_message("The world send rate must be a finite number!");
                     return false;
                 }
-                if hertz > 1000 {
+                if hertz < 0.0 {
                     self.players[player]
-                        .send_error_message("The world send rate cannot go higher than 1000!");
+                        .send_error_message("The world send rate cannot be negative!");
+                    return false;
+                }
+                if hertz > 1000.0 {
+                    self.players[player]
+                        .send_error_message("The world send rate cannot be higher than 1000!");
                     return false;
                 }
 
-                self.world_send_rate = WorldSendRate(hertz);
-                self.reset_timings();
+                self.world.world_send_rate = WorldSendRate(hertz);
+                self.world.pending_sounds.clear();
+                self.last_world_send_time = Instant::now();
                 self.players[player]
                     .send_system_message("The world send rate was successfully set.");
             }
@@ -618,7 +632,7 @@ pub static DECLARE_COMMANDS: LazyLock<PacketEncoder> = LazyLock::new(|| {
                 children: vec![],
                 redirect_node: None,
                 name: Some("rtps"),
-                parser: Some(Parser::Integer(0, i32::MAX)),
+                parser: Some(Parser::Float(0.0, f32::MAX)),
                 suggestions_type: None,
             },
             // 8: /radvance
@@ -1002,13 +1016,13 @@ pub static DECLARE_COMMANDS: LazyLock<PacketEncoder> = LazyLock::new(|| {
                 parser: None,
                 suggestions_type: None,
             },
-            // 50: /worldsendrate [rticks]
+            // 50: /worldsendrate [hertz]
             Node {
                 flags: (CommandFlags::ARGUMENT | CommandFlags::EXECUTABLE).bits() as i8,
                 children: vec![],
                 redirect_node: None,
                 name: Some("hertz"),
-                parser: Some(Parser::Integer(0, 1000)),
+                parser: Some(Parser::Float(0.0, 1000.0)),
                 suggestions_type: None,
             },
             // 51: /wsr

--- a/crates/core/src/plot/data.rs
+++ b/crates/core/src/plot/data.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 pub fn sleep_time_for_tps(tps: Tps) -> Duration {
     match tps {
         Tps::Limited(tps) => {
-            if tps > 10 {
-                Duration::from_micros(1_000_000 / tps as u64)
+            if tps > 10.0 {
+                Duration::from_secs_f64(1.0 / f64::from(tps))
             } else {
                 Duration::from_millis(50)
             }
@@ -50,10 +50,13 @@ static EMPTY_PLOT: LazyLock<PlotData> = LazyLock::new(|| {
             chunks,
             to_be_ticked: Vec::new(),
             packet_senders: Vec::new(),
+            world_send_rate: WorldSendRate::default(),
+            pending_block_entities: Default::default(),
+            pending_sounds: Default::default(),
         };
         let chunk_data: Vec<ChunkData> = world.chunks.iter_mut().map(ChunkData::new).collect();
         PlotData {
-            tps: Tps::Limited(10),
+            tps: Tps::Limited(10.0),
             world_send_rate: WorldSendRate::default(),
             chunk_data,
             pending_ticks: Vec::new(),

--- a/crates/core/src/plot/mod.rs
+++ b/crates/core/src/plot/mod.rs
@@ -27,6 +27,7 @@ use mchprs_text::TextComponent;
 use mchprs_world::storage::Chunk;
 use mchprs_world::{TickEntry, TickPriority, World};
 use monitor::TimingsMonitor;
+use rustc_hash::FxHashMap;
 use scoreboard::RedpilerState;
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -56,6 +57,8 @@ pub const PLOT_BLOCK_HEIGHT: i32 = PLOT_SECTIONS as i32 * 16;
 
 const ERROR_IO_ONLY: &str = "This plot cannot be interacted with while redpiler is active with `--io-only`. To stop redpiler, run `/redpiler reset`.";
 
+const MAX_BATCH_SIZE: u32 = 50_000;
+
 pub struct Plot {
     pub world: PlotWorld,
     pub players: Vec<Player>,
@@ -70,7 +73,6 @@ pub struct Plot {
 
     // Timings
     tps: Tps,
-    world_send_rate: WorldSendRate,
     last_update_time: Instant,
     lag_time: Duration,
     last_nspt: Option<Duration>,
@@ -99,6 +101,9 @@ pub struct PlotWorld {
     pub chunks: Vec<Chunk>,
     pub to_be_ticked: Vec<TickEntry>,
     pub packet_senders: Vec<PlayerPacketSender>,
+    world_send_rate: WorldSendRate,
+    pending_block_entities: FxHashMap<BlockPos, CBlockEntityData>,
+    pending_sounds: FxHashMap<BlockPos, CSoundEffect>,
 }
 
 impl PlotWorld {
@@ -162,6 +167,7 @@ impl World for PlotWorld {
     }
 
     fn delete_block_entity(&mut self, pos: BlockPos) {
+        self.pending_block_entities.remove(&pos);
         let chunk_index = match self.get_chunk_index_for_block(pos.x, pos.z) {
             Some(idx) => idx,
             None => return,
@@ -189,11 +195,10 @@ impl World for PlotWorld {
                 // For now the only nbt we send to the client is sign data
                 ty: block_entity.ty(),
                 nbt: nbt.content,
-            }
-            .encode();
-            for player in &self.packet_senders {
-                player.send_packet(&block_entity_data);
-            }
+            };
+            self.pending_block_entities.insert(pos, block_entity_data);
+        } else {
+            self.pending_block_entities.remove(&pos);
         }
         let chunk = &mut self.chunks[chunk_index];
         chunk.set_block_entity(BlockPos::new(pos.x & 0xF, pos.y, pos.z & 0xF), block_entity);
@@ -228,6 +233,9 @@ impl World for PlotWorld {
         volume: f32,
         pitch: f32,
     ) {
+        if self.world_send_rate.0 == 0.0 {
+            return;
+        }
         // FIXME: We do not know the players location here, so we send the sound packet to all
         // players A notchian server would only send to players in hearing distance
         // (volume.clamp(0.0, 1.0) * 16.0)
@@ -244,12 +252,8 @@ impl World for PlotWorld {
             pitch,
             // FIXME: How do we decide this?
             seed: 0,
-        }
-        .encode();
-
-        for player in &self.packet_senders {
-            player.send_packet(&sound_effect_data);
-        }
+        };
+        self.pending_sounds.insert(pos, sound_effect_data);
     }
 
     fn flush_block_changes(&mut self) {
@@ -261,6 +265,18 @@ impl World for PlotWorld {
         }
         for chunk in &mut self.chunks {
             chunk.reset_multi_blocks();
+        }
+        for (_, block_entity) in self.pending_block_entities.drain() {
+            let encoded = block_entity.encode();
+            for player in &self.packet_senders {
+                player.send_packet(&encoded);
+            }
+        }
+        for (_, sound) in self.pending_sounds.drain() {
+            let encoded = sound.encode();
+            for player in &self.packet_senders {
+                player.send_packet(&encoded);
+            }
         }
     }
 }
@@ -297,17 +313,19 @@ impl Plot {
         }
     }
 
-    /// Send a block change to all connected players
-    pub fn send_block_change(&mut self, pos: BlockPos, id: u32) {
-        let block_change = CBlockUpdate {
-            block_id: id as i32,
-            x: pos.x,
-            y: pos.y,
-            z: pos.z,
-        }
-        .encode();
-        for player in &mut self.players {
-            player.client.send_packet(&block_change);
+    pub fn send_block_corrections(&mut self, positions: &[BlockPos]) {
+        self.publish_world();
+        for pos in positions {
+            let block_change = CBlockUpdate {
+                block_id: self.world.get_block_raw(*pos) as i32,
+                x: pos.x,
+                y: pos.y,
+                z: pos.z,
+            }
+            .encode();
+            for player in &self.players {
+                player.client.send_packet(&block_change);
+            }
         }
     }
 
@@ -354,6 +372,7 @@ impl Plot {
     fn set_pressure_plate(&mut self, pos: BlockPos, new_powered: bool) {
         if self.redpiler.is_active() {
             self.redpiler.set_pressure_plate(pos, new_powered);
+            self.publish_world();
             return;
         }
 
@@ -369,6 +388,7 @@ impl Plot {
         } else {
             warn!("Block at {} is not a pressure plate", pos);
         }
+        self.publish_world();
     }
 
     fn are_players_on_block(&mut self, pos: BlockPos) -> bool {
@@ -382,6 +402,9 @@ impl Plot {
 
     fn enter_plot(&mut self, player: Player) {
         self.save();
+        if self.players.is_empty() {
+            self.world.pending_sounds.clear();
+        }
         let spawn_player = player.spawn_packet().encode();
         let metadata = player.metadata_packet().encode();
         let entity_equipment = player.equippment_packet();
@@ -438,15 +461,15 @@ impl Plot {
                     .client
                     .send_packet(&Chunk::encode_empty_packet(chunk_x, chunk_z, PLOT_SECTIONS));
             } else {
-                let chunk_data = self.world.chunks
-                    [self.world.get_chunk_index_for_chunk(chunk_x, chunk_z)]
-                .encode_packet();
+                let chunk_idx = self.world.get_chunk_index_for_chunk(chunk_x, chunk_z);
+                let chunk_data = self.world.chunks[chunk_idx].encode_packet();
                 self.players[player_idx].client.send_packet(&chunk_data);
             }
         }
     }
 
     pub fn update_view_pos_for_player(&mut self, player_idx: usize, force_load: bool) {
+        self.publish_world();
         let view_distance = CONFIG.view_distance as i32;
         let (chunk_x, chunk_z) = self.players[player_idx].pos.chunk_pos();
         let last_chunk_x = self.players[player_idx].last_chunk_x;
@@ -493,10 +516,7 @@ impl Plot {
         let block_face = BlockFace::from_id(use_item_on.face as u32);
 
         let cancel = |plot: &mut Plot| {
-            plot.send_block_change(block_pos, plot.world.get_block_raw(block_pos));
-
-            let offset_pos = block_pos.offset(block_face);
-            plot.send_block_change(offset_pos, plot.world.get_block_raw(offset_pos));
+            plot.send_block_corrections(&[block_pos, block_pos.offset(block_face)]);
         };
 
         let selected_slot = self.players[player].selected_slot as usize;
@@ -546,8 +566,7 @@ impl Plot {
             let lever_or_button = matches!(block, Block::Lever { .. } | Block::StoneButton { .. });
             if lever_or_button && !self.players[player].crouching {
                 self.redpiler.on_use_block(block_pos);
-                self.redpiler.flush(&mut self.world);
-                self.world.flush_block_changes();
+                self.publish_world();
                 return;
             } else {
                 match self.redpiler.current_flags() {
@@ -609,7 +628,7 @@ impl Plot {
         if let Some(item) = item_in_hand {
             let has_permission = self.players[player].has_permission("worldedit.selection.pos");
             if item.item_type == (Item::WoodenAxe) && has_permission {
-                self.send_block_change(block_pos, block.get_id());
+                self.send_block_corrections(&[block_pos]);
                 if let Some(pos) = self.players[player].first_position
                     && pos == block_pos
                 {
@@ -624,19 +643,19 @@ impl Plot {
             let player = &mut self.players[player];
             if owner != player.uuid && !player.has_permission("plots.admin.interact.other") {
                 player.send_no_permission_message();
-                self.send_block_change(block_pos, block.get_id());
+                self.send_block_corrections(&[block_pos]);
                 return;
             }
         } else if !self.players[player].has_permission("plots.admin.interact.unowned") {
             self.players[player].send_no_permission_message();
-            self.send_block_change(block_pos, block.get_id());
+            self.send_block_corrections(&[block_pos]);
             return;
         }
 
         match self.redpiler.current_flags() {
             Some(flags) if flags.io_only => {
                 self.players[player].send_error_message(ERROR_IO_ONLY);
-                self.send_block_change(block_pos, block.get_id());
+                self.send_block_corrections(&[block_pos]);
                 return;
             }
             _ => {}
@@ -672,6 +691,14 @@ impl Plot {
         self.last_update_time = Instant::now();
         self.last_nspt = None;
         self.timings.reset_timings();
+    }
+
+    fn publish_world(&mut self) {
+        if self.redpiler.is_active() {
+            self.redpiler.flush(&mut self.world);
+        }
+        self.world.flush_block_changes();
+        self.last_world_send_time = Instant::now();
     }
 
     fn start_redpiler(&mut self, options: CompilerOptions) {
@@ -986,26 +1013,33 @@ impl Plot {
             let now = Instant::now();
             self.last_player_time = now;
 
-            let world_send_rate =
-                Duration::from_nanos(1_000_000_000 / self.world_send_rate.0 as u64);
+            let world_send_interval =
+                Duration::try_from_secs_f64(1.0 / f64::from(self.world.world_send_rate.0))
+                    .unwrap_or(Duration::MAX);
 
+            let batch_interval = world_send_interval.min(Duration::from_millis(50));
             let max_batch_size = match self.last_nspt {
                 Some(Duration::ZERO) | None => 1,
                 Some(last_nspt) => {
-                    let ticks_fit = (world_send_rate.as_nanos() / last_nspt.as_nanos()) as u64;
-                    // A tick previously took longer than the world send rate.
+                    let ticks_fit = batch_interval.as_nanos() / last_nspt.as_nanos();
+                    // A tick previously took longer than the batch interval.
                     // Run at least one just so we're not stuck doing nothing
-                    ticks_fit.max(1)
+                    ticks_fit.clamp(1, u128::from(MAX_BATCH_SIZE)) as u32
                 }
             };
 
             let batch_size = match self.tps {
-                Tps::Limited(tps) if tps != 0 => {
-                    let dur_per_tick = Duration::from_nanos(1_000_000_000 / tps as u64);
+                Tps::Limited(tps) if tps > 0.0 => {
+                    // Very high rates can round the interval to zero and cause division by zero.
+                    let dur_per_tick = Duration::try_from_secs_f64(1.0 / f64::from(tps))
+                        .unwrap_or(Duration::MAX)
+                        .max(Duration::from_nanos(1));
                     self.lag_time += now - self.last_update_time;
-                    let batch_size = (self.lag_time.as_nanos() / dur_per_tick.as_nanos()) as u64;
-                    self.lag_time -= dur_per_tick * batch_size as u32;
-                    batch_size.min(max_batch_size)
+                    let ticks_behind = self.lag_time.as_nanos() / dur_per_tick.as_nanos();
+                    self.lag_time = Duration::from_nanos(
+                        (self.lag_time.as_nanos() % dur_per_tick.as_nanos()) as u64,
+                    );
+                    ticks_behind.min(u128::from(max_batch_size)) as u32
                 }
                 Tps::Unlimited => max_batch_size,
                 _ => 0,
@@ -1013,10 +1047,6 @@ impl Plot {
 
             self.last_update_time = now;
             if batch_size != 0 {
-                // 50_000 (= 3.33 MHz) here is arbitrary.
-                // We just need a number that's not too high so we actually get around to sending
-                // block updates.
-                let batch_size = batch_size.min(50_000) as u32;
                 let mut ticks_completed = batch_size;
                 if self.redpiler.is_active() {
                     self.tickn(batch_size as u64);
@@ -1042,7 +1072,7 @@ impl Plot {
 
             let now = Instant::now();
             let time_since_last_world_send = now - self.last_world_send_time;
-            if time_since_last_world_send > world_send_rate {
+            if time_since_last_world_send > world_send_interval {
                 self.last_world_send_time = now;
                 self.world.flush_block_changes();
             }
@@ -1126,9 +1156,11 @@ impl Plot {
             chunks,
             to_be_ticked: plot_data.pending_ticks,
             packet_senders: Vec::new(),
+            world_send_rate: plot_data.world_send_rate,
+            pending_block_entities: FxHashMap::default(),
+            pending_sounds: FxHashMap::default(),
         };
         let tps = plot_data.tps;
-        let world_send_rate = plot_data.world_send_rate;
         Plot {
             last_player_time: Instant::now(),
             last_update_time: Instant::now(),
@@ -1144,7 +1176,6 @@ impl Plot {
             running: true,
             auto_redpiler: CONFIG.auto_redpiler,
             tps,
-            world_send_rate,
             always_running,
             redpiler: Default::default(),
             timings: TimingsMonitor::new(tps),
@@ -1184,7 +1215,7 @@ impl Plot {
         let chunk_data: Vec<ChunkData> = world.chunks.iter_mut().map(ChunkData::new).collect();
         let data = PlotData {
             tps: self.tps,
-            world_send_rate: self.world_send_rate,
+            world_send_rate: world.world_send_rate,
             chunk_data,
             pending_ticks: world.to_be_ticked.clone(),
         };

--- a/crates/core/src/plot/monitor.rs
+++ b/crates/core/src/plot/monitor.rs
@@ -176,11 +176,13 @@ impl TimingsMonitor {
 
                 let tps = data.tps.get();
                 let ticking = data.ticking.load(Ordering::Relaxed);
-                if !(ticking && was_ticking_before)
-                    || tps != last_tps
-                    || data.reset_timings.load(Ordering::Relaxed) > 0
-                {
-                    data.reset_timings.fetch_sub(1, Ordering::Relaxed);
+                let resetting = data
+                    .reset_timings
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok();
+                if !(ticking && was_ticking_before) || tps != last_tps || resetting {
                     was_ticking_before = ticking;
                     last_tps = tps;
                     continue;

--- a/crates/core/src/plot/monitor.rs
+++ b/crates/core/src/plot/monitor.rs
@@ -7,33 +7,41 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 use tracing::warn;
 
+const MONITOR_INTERVAL: Duration = Duration::from_millis(500);
+
 #[derive(Default)]
 struct AtomicTps {
-    tps: AtomicU32,
-    unlimited: AtomicBool,
+    tps_bits: AtomicU32,
 }
 
 impl AtomicTps {
     fn from_tps(tps: Tps) -> Self {
-        match tps {
-            Tps::Limited(tps) => AtomicTps {
-                tps: AtomicU32::new(tps),
-                unlimited: AtomicBool::new(false),
-            },
-            Tps::Unlimited => AtomicTps {
-                tps: AtomicU32::new(0),
-                unlimited: AtomicBool::new(true),
-            },
+        AtomicTps {
+            tps_bits: AtomicU32::new(Self::tps_to_bits(tps)),
         }
     }
 
     fn update(&self, tps: Tps) {
+        self.tps_bits
+            .store(Self::tps_to_bits(tps), Ordering::Relaxed);
+    }
+
+    fn tps_to_bits(tps: Tps) -> u32 {
         match tps {
-            Tps::Limited(tps) => {
-                self.tps.store(tps, Ordering::Relaxed);
-                self.unlimited.store(false, Ordering::Relaxed);
+            Tps::Limited(tps) if tps.is_nan() => {
+                panic!("Tps should never be NaN under any circumstance")
             }
-            Tps::Unlimited => self.unlimited.store(true, Ordering::Relaxed),
+            Tps::Limited(tps) => tps.to_bits(),
+            Tps::Unlimited => f32::NAN.to_bits(),
+        }
+    }
+
+    fn get(&self) -> Tps {
+        let tps = f32::from_bits(self.tps_bits.load(Ordering::Relaxed));
+        if tps.is_nan() {
+            Tps::Unlimited
+        } else {
+            Tps::Limited(tps)
         }
     }
 }
@@ -148,13 +156,13 @@ impl TimingsMonitor {
 
     fn run_thread(data: Arc<MonitorData>) -> JoinHandle<()> {
         thread::spawn(move || {
-            let mut last_tps = data.tps.tps.load(Ordering::Relaxed);
+            let mut last_tps = data.tps.get();
             let mut last_ticks_count = data.ticks_passed.load(Ordering::Relaxed);
             let mut was_ticking_before = data.ticking.load(Ordering::Relaxed);
 
             let mut behind_for = 0;
             loop {
-                thread::sleep(Duration::from_millis(500));
+                thread::sleep(MONITOR_INTERVAL);
                 if !data.running.load(Ordering::Relaxed) {
                     return;
                 }
@@ -166,7 +174,7 @@ impl TimingsMonitor {
                 let ticks_passed = (ticks_count - last_ticks_count) as u32;
                 last_ticks_count = ticks_count;
 
-                let tps = data.tps.tps.load(Ordering::Relaxed);
+                let tps = data.tps.get();
                 let ticking = data.ticking.load(Ordering::Relaxed);
                 if !(ticking && was_ticking_before)
                     || tps != last_tps
@@ -178,9 +186,16 @@ impl TimingsMonitor {
                     continue;
                 }
 
-                // 5% threshold
-                if data.tps.unlimited.load(Ordering::Relaxed) || ticks_passed < (tps / 2) * 95 / 100
-                {
+                // 5% threshold, floored: an on-schedule plot delivers floor or ceil of the expected ticks
+                let is_behind = match tps {
+                    Tps::Unlimited => false,
+                    Tps::Limited(tps) => {
+                        let expected = f64::from(tps) * MONITOR_INTERVAL.as_secs_f64();
+                        f64::from(ticks_passed) < (expected * 0.95).floor()
+                    }
+                };
+
+                if is_behind {
                     behind_for += 1;
                 } else {
                     behind_for = 0;
@@ -189,10 +204,6 @@ impl TimingsMonitor {
 
                 if behind_for >= 3 {
                     data.too_slow.store(true, Ordering::Relaxed);
-                    // warn!(
-                    //     "running behind by {} ticks",
-                    //     ((tps / 2) * 95 / 100) - ticks_passed
-                    // );
                 }
 
                 // The timings record will only go back 15 minutes.

--- a/crates/core/src/plot/packet_handlers.rs
+++ b/crates/core/src/plot/packet_handlers.rs
@@ -451,5 +451,6 @@ impl ServerBoundPacketHandler for Plot {
         }
         self.world
             .set_block_entity(pos, BlockEntity::Sign(Box::new(block_entity)));
+        self.publish_world();
     }
 }

--- a/crates/core/src/plot/worldedit/mod.rs
+++ b/crates/core/src/plot/worldedit/mod.rs
@@ -155,6 +155,9 @@ pub fn execute_command(
         flags: ctx_flags,
     };
     (command.execute_fn)(ctx);
+    if command.mutates_world {
+        plot.publish_world();
+    }
     true
 }
 

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -2,16 +2,14 @@ use crate::backend::direct::node::ForwardLinks;
 use crate::compile_graph::{CompileGraph, Direction, LinkType, NodeIdx};
 use crate::{CompilerOptions, TaskMonitor};
 use itertools::Itertools;
-use mchprs_blocks::blocks::{Block, Instrument};
-use mchprs_blocks::BlockPos;
+use mchprs_blocks::blocks::Block;
 use mchprs_world::TickEntry;
 use rustc_hash::FxHashMap;
-use smallvec::SmallVec;
 use std::sync::Arc;
 use tracing::trace;
 
 use super::node::{ForwardLink, Node, NodeId, NodeInput, NodeType, Nodes, NonMaxU8};
-use super::DirectBackend;
+use super::{DirectBackend, NoteBlockInfo};
 
 #[derive(Debug, Default)]
 struct FinalGraphStats {
@@ -26,7 +24,7 @@ fn compile_node(
     node_idx: NodeIdx,
     nodes_len: usize,
     nodes_map: &FxHashMap<NodeIdx, usize>,
-    noteblock_info: &mut Vec<(SmallVec<[BlockPos; 1]>, Instrument, u8)>,
+    noteblock_info: &mut Vec<NoteBlockInfo>,
     forward_links: &mut ForwardLinks,
     stats: &mut FinalGraphStats,
 ) -> Node {
@@ -123,11 +121,12 @@ fn compile_node(
         CNodeType::Constant => NodeType::Constant,
         CNodeType::NoteBlock { instrument, note } => {
             let noteblock_id = noteblock_info.len().try_into().unwrap();
-            noteblock_info.push((
-                node.block.iter().copied().map(|(pos, _)| pos).collect(),
-                *instrument,
-                *note,
-            ));
+            noteblock_info.push(NoteBlockInfo {
+                positions: node.block.iter().copied().map(|(pos, _)| pos).collect(),
+                instrument: *instrument,
+                note: *note,
+                pending: false,
+            });
             NodeType::NoteBlock { noteblock_id }
         }
     };

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -109,8 +109,11 @@ impl TickScheduler {
     }
 }
 
-enum Event {
-    NoteBlockPlay { noteblock_id: u16 },
+struct NoteBlockInfo {
+    positions: SmallVec<[BlockPos; 1]>,
+    instrument: Instrument,
+    note: u8,
+    pending: bool,
 }
 
 #[derive(Default)]
@@ -120,8 +123,7 @@ pub struct DirectBackend {
     blocks: Vec<SmallVec<[(BlockPos, Block); 1]>>,
     pos_map: FxHashMap<BlockPos, NodeId>,
     scheduler: TickScheduler,
-    events: Vec<Event>,
-    noteblock_info: Vec<(SmallVec<[BlockPos; 1]>, Instrument, u8)>,
+    noteblock_info: Vec<NoteBlockInfo>,
 }
 
 impl DirectBackend {
@@ -164,7 +166,7 @@ impl DirectBackend {
 
             update::update_node(
                 &mut self.scheduler,
-                &mut self.events,
+                &mut self.noteblock_info,
                 &mut self.nodes,
                 update,
             );
@@ -205,7 +207,6 @@ impl JITBackend for DirectBackend {
         self.forward_links.clear();
         self.pos_map.clear();
         self.noteblock_info.clear();
-        self.events.clear();
     }
 
     fn on_use_block(&mut self, pos: BlockPos) {
@@ -248,16 +249,6 @@ impl JITBackend for DirectBackend {
     }
 
     fn flush<W: World>(&mut self, world: &mut W, io_only: bool) {
-        for event in self.events.drain(..) {
-            match event {
-                Event::NoteBlockPlay { noteblock_id } => {
-                    let (positions, instrument, note) = &self.noteblock_info[noteblock_id as usize];
-                    for pos in positions.iter().copied() {
-                        noteblock::play_note(world, pos, *instrument, *note);
-                    }
-                }
-            }
-        }
         for (i, node) in self.nodes.inner_mut().iter_mut().enumerate() {
             if !node.changed || (io_only && !node.is_io) {
                 continue;
@@ -277,6 +268,13 @@ impl JITBackend for DirectBackend {
                     repeater.locked = node.locked;
                 }
                 world.set_block(*pos, *block);
+            }
+        }
+        for info in &mut self.noteblock_info {
+            if mem::take(&mut info.pending) {
+                for pos in info.positions.iter().copied() {
+                    noteblock::play_note(world, pos, info.instrument, info.note);
+                }
             }
         }
     }

--- a/crates/redpiler/src/backend/direct/update.rs
+++ b/crates/redpiler/src/backend/direct/update.rs
@@ -6,7 +6,7 @@ use super::*;
 #[inline(always)]
 pub(super) fn update_node(
     scheduler: &mut TickScheduler,
-    events: &mut Vec<Event>,
+    noteblock_info: &mut [NoteBlockInfo],
     nodes: &mut Nodes,
     node_id: NodeId,
 ) {
@@ -98,7 +98,7 @@ pub(super) fn update_node(
             if node.powered != should_be_powered {
                 set_node(node, should_be_powered);
                 if should_be_powered {
-                    events.push(Event::NoteBlockPlay { noteblock_id });
+                    noteblock_info[noteblock_id as usize].pending = true;
                 }
             }
         }

--- a/crates/save_data/src/plot_data.rs
+++ b/crates/save_data/src/plot_data.rs
@@ -1,4 +1,5 @@
 mod fixer;
+mod v2_to_v3;
 
 use self::fixer::FixInfo;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -18,7 +19,8 @@ use thiserror::Error;
 /// 0: Initial plot data file with header (MC 1.18.2)
 /// 1: Add world send rate
 /// 2: Update to MC 1.20.4
-pub const VERSION: u32 = 2;
+/// 3: Change Tps and WorldSendRate to support real values (f32)
+pub const VERSION: u32 = 3;
 
 #[derive(Error, Debug)]
 pub enum PlotLoadError {
@@ -132,18 +134,18 @@ impl ChunkData {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum Tps {
-    Limited(u32),
+    Limited(f32),
     Unlimited,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WorldSendRate(pub u32);
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct WorldSendRate(pub f32);
 
 impl Default for WorldSendRate {
     fn default() -> Self {
-        Self(60)
+        Self(60.0)
     }
 }
 

--- a/crates/save_data/src/plot_data/fixer.rs
+++ b/crates/save_data/src/plot_data/fixer.rs
@@ -7,6 +7,7 @@
 //! seperate download. As our save format changes in the future, the fixer
 //! module may become quite big.
 
+use super::v2_to_v3;
 use super::{PlotData, PlotLoadError};
 use crate::plot_data::VERSION;
 use std::fs;
@@ -42,6 +43,7 @@ pub fn try_fix(path: impl AsRef<Path>, info: FixInfo) -> Result<Option<PlotData>
         FixInfo::OldVersion {
             version: version @ 0..=1,
         } => return Err(PlotLoadError::ConversionUnavailable(version)),
+        FixInfo::OldVersion { version: 2 } => v2_to_v3::convert_v2_to_v3(&path)?,
         _ => None,
     };
 

--- a/crates/save_data/src/plot_data/fixer.rs
+++ b/crates/save_data/src/plot_data/fixer.rs
@@ -23,12 +23,13 @@ fn make_backup(path: impl AsRef<Path>) -> Result<(), PlotLoadError> {
     let path = path.as_ref();
     let mut backup_path = path.with_extension("bak");
     if backup_path.exists() {
-        let num = 1;
+        let mut num = 1;
         loop {
             backup_path = path.with_extension(format!("bak.{}", num));
             if !backup_path.exists() {
                 break;
             }
+            num += 1;
         }
     }
     fs::rename(path, backup_path)?;

--- a/crates/save_data/src/plot_data/v2_to_v3.rs
+++ b/crates/save_data/src/plot_data/v2_to_v3.rs
@@ -1,0 +1,63 @@
+//! Migration from version 2 to version 3, which turned Tps and WorldSendRate from u32 into f32
+
+use super::{ChunkData, PlotData, PlotLoadError, Tps, WorldSendRate, PLOT_MAGIC};
+use byteorder::{LittleEndian, ReadBytesExt};
+use mchprs_world::TickEntry;
+use serde::Deserialize;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use tracing::debug;
+
+#[derive(Deserialize)]
+enum TpsV2 {
+    Limited(u32),
+    Unlimited,
+}
+
+#[derive(Deserialize)]
+struct WorldSendRateV2(u32);
+
+#[derive(Deserialize)]
+struct PlotDataV2 {
+    tps: TpsV2,
+    world_send_rate: WorldSendRateV2,
+    chunk_data: Vec<ChunkData>,
+    pending_ticks: Vec<TickEntry>,
+}
+
+pub fn convert_v2_to_v3(path: impl AsRef<Path>) -> Result<Option<PlotData>, PlotLoadError> {
+    let mut file = File::open(&path)?;
+
+    let mut magic = [0; 8];
+    file.read_exact(&mut magic)?;
+    if &magic != PLOT_MAGIC {
+        return Ok(None);
+    }
+
+    let version = file.read_u32::<LittleEndian>()?;
+    if version != 2 {
+        return Ok(None);
+    }
+
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let old_data: PlotDataV2 = bincode::deserialize(&buf)?;
+
+    let new_tps = match old_data.tps {
+        TpsV2::Limited(val) => Tps::Limited(val as f32),
+        TpsV2::Unlimited => Tps::Unlimited,
+    };
+
+    let new_world_send_rate = WorldSendRate(old_data.world_send_rate.0 as f32);
+
+    let new_data = PlotData {
+        tps: new_tps,
+        world_send_rate: new_world_send_rate,
+        chunk_data: old_data.chunk_data,
+        pending_ticks: old_data.pending_ticks,
+    };
+
+    debug!("Successfully converted plot data from version 2 to version 3");
+    Ok(Some(new_data))
+}


### PR DESCRIPTION
Follow-up to #203.
`/rtps` and `/wsr` accept fractional rates, stored as `f32` in plot format v3 with a migration from v2.
Tick batches are computed from the fractional rate, and the tick duration is clamped to at least 1 ns, which fixes the divide-by-zero crash at very high rates from #247.
The timings monitor floors its running-behind threshold for fractional rates and no longer underflows its reset counter after pausing or changing rates.
World updates are published together at the send rate, and `wsr 0` disables periodic sends.
Plot conversion no longer hangs when `.bak` and `.bak.1` already exist.

The further ideas from the first version of this description (deferring the flush, giving the backend a deadline) are implemented in #261.
