### PR TITLE
Optimize flush performance and refactor backend with execution context

### DIFF
--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -1,3 +1,4 @@
+use crate::backend::direct::Options;
 use crate::compile_graph::{CompileGraph, LinkType, NodeIdx};
 use crate::TaskMonitor;
 use itertools::Itertools;
@@ -28,6 +29,7 @@ fn compile_node(
     nodes_len: usize,
     nodes_map: &FxHashMap<NodeIdx, usize>,
     noteblock_info: &mut Vec<(BlockPos, Instrument, u32)>,
+    options: &Options,
     stats: &mut FinalGraphStats,
 ) -> Node {
     let node = &graph[node_idx];
@@ -138,7 +140,7 @@ fn compile_node(
         locked: node.state.repeater_locked,
         pending_tick: false,
         changed: false,
-        is_io: node.is_input || node.is_output,
+        is_frozen: !(node.is_input || node.is_output) && options.is_io_only,
     }
 }
 
@@ -166,6 +168,7 @@ pub fn compile(
                 nodes_len,
                 &nodes_map,
                 &mut backend.noteblock_info,
+                &backend.options,
                 &mut stats,
             )
         })

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -1,5 +1,5 @@
 use crate::compile_graph::{CompileGraph, LinkType, NodeIdx};
-use crate::{CompilerOptions, TaskMonitor};
+use crate::TaskMonitor;
 use itertools::Itertools;
 use mchprs_blocks::blocks::{Block, Instrument};
 use mchprs_blocks::BlockPos;
@@ -146,7 +146,6 @@ pub fn compile(
     backend: &mut DirectBackend,
     graph: CompileGraph,
     ticks: Vec<TickEntry>,
-    options: &CompilerOptions,
     _monitor: Arc<TaskMonitor>,
 ) {
     // Create a mapping from compile to backend node indices
@@ -197,10 +196,5 @@ pub fn compile(
             );
             backend.nodes[*node].pending_tick = true;
         }
-    }
-
-    // Dot file output
-    if options.export_dot_graph {
-        std::fs::write("backend_graph.dot", format!("{}", backend)).unwrap();
     }
 }

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -190,9 +190,11 @@ pub fn compile(
     // Schedule backend ticks
     for entry in ticks {
         if let Some(node) = backend.pos_map.get(&entry.pos) {
-            backend
-                .scheduler
-                .schedule_tick(*node, entry.ticks_left as usize, entry.tick_priority);
+            backend.execution_context.schedule_tick(
+                *node,
+                entry.ticks_left as usize,
+                entry.tick_priority,
+            );
             backend.nodes[*node].pending_tick = true;
         }
     }

--- a/crates/redpiler/src/backend/direct/execution_context.rs
+++ b/crates/redpiler/src/backend/direct/execution_context.rs
@@ -1,0 +1,98 @@
+use mchprs_blocks::{blocks::Block, BlockPos};
+use mchprs_world::{TickPriority, World};
+use tracing::warn;
+
+use super::{node::NodeId, Event};
+
+#[derive(Default, Clone)]
+pub struct Queues([Vec<NodeId>; ExecutionContext::NUM_PRIORITIES]);
+
+impl Queues {
+    pub fn drain_iter(&mut self) -> impl Iterator<Item = NodeId> + '_ {
+        let [q0, q1, q2, q3] = &mut self.0;
+        let [q0, q1, q2, q3] = [q0, q1, q2, q3].map(|q| q.drain(..));
+        q0.chain(q1).chain(q2).chain(q3)
+    }
+}
+
+#[derive(Default)]
+pub struct ExecutionContext {
+    queues_deque: [Queues; Self::NUM_QUEUES],
+    pos: usize,
+    events: Vec<Event>,
+}
+
+impl ExecutionContext {
+    const NUM_PRIORITIES: usize = 4;
+    const NUM_QUEUES: usize = 16;
+
+    pub(super) fn reset<W: World>(&mut self, world: &mut W, blocks: &[Option<(BlockPos, Block)>]) {
+        for (idx, queues) in self.queues_deque.iter().enumerate() {
+            let delay = if self.pos >= idx {
+                idx + Self::NUM_QUEUES
+            } else {
+                idx
+            } - self.pos;
+            for (entries, priority) in queues.0.iter().zip(Self::priorities()) {
+                for node in entries {
+                    let Some((pos, _)) = blocks[node.index()] else {
+                        warn!("Cannot schedule tick for node {:?} because block information is missing", node);
+                        continue;
+                    };
+                    world.schedule_tick(pos, delay as u32, priority);
+                }
+            }
+        }
+        for queues in self.queues_deque.iter_mut() {
+            for queue in queues.0.iter_mut() {
+                queue.clear();
+            }
+        }
+
+        self.events.clear();
+    }
+
+    pub(super) fn schedule_tick(&mut self, node: NodeId, delay: usize, priority: TickPriority) {
+        self.queues_deque[(self.pos + delay) % Self::NUM_QUEUES].0[priority as usize].push(node);
+    }
+
+    pub(super) fn queues_this_tick(&mut self) -> Queues {
+        self.pos = (self.pos + 1) % Self::NUM_QUEUES;
+        std::mem::take(&mut self.queues_deque[self.pos])
+    }
+
+    pub(super) fn end_tick(&mut self, mut queues: Queues) {
+        for queue in &mut queues.0 {
+            queue.clear();
+        }
+        self.queues_deque[self.pos] = queues;
+    }
+
+    fn priorities() -> [TickPriority; Self::NUM_PRIORITIES] {
+        [
+            TickPriority::Highest,
+            TickPriority::Higher,
+            TickPriority::High,
+            TickPriority::Normal,
+        ]
+    }
+
+    pub(super) fn has_pending_ticks(&self) -> bool {
+        for queues in &self.queues_deque {
+            for queue in &queues.0 {
+                if !queue.is_empty() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub(super) fn push_event(&mut self, event: Event) {
+        self.events.push(event);
+    }
+
+    pub(super) fn drain_events(&mut self) -> impl Iterator<Item = Event> + '_ {
+        self.events.drain(..)
+    }
+}

--- a/crates/redpiler/src/backend/direct/flush.rs
+++ b/crates/redpiler/src/backend/direct/flush.rs
@@ -1,0 +1,50 @@
+use mchprs_blocks::blocks::Block;
+use mchprs_redstone::noteblock;
+use mchprs_world::World;
+
+use crate::{
+    backend::direct::{DirectBackend, Event},
+    block_powered_mut,
+};
+
+impl DirectBackend {
+    pub(crate) fn flush_events<W: World>(&mut self, world: &mut W) {
+        for event in self.execution_context.drain_events() {
+            match event {
+                Event::NoteBlockPlay { noteblock_id } => {
+                    let (pos, instrument, note) = self.noteblock_info[noteblock_id as usize];
+                    noteblock::play_note(world, pos, instrument, note);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn flush_block_changes<W: World>(&mut self, world: &mut W) {
+        for i in self.execution_context.drain_changes() {
+            let node = &mut self.nodes[i];
+            let Some((pos, block)) = &mut self.blocks[i.index()] else {
+                continue;
+            };
+            if let Some(powered) = block_powered_mut(block) {
+                *powered = node.powered
+            }
+            if let Block::RedstoneWire { wire, .. } = block {
+                wire.power = node.output_power
+            };
+            if let Block::RedstoneRepeater { repeater } = block {
+                repeater.locked = node.locked;
+            }
+            world.set_block(*pos, *block);
+            node.changed = false;
+        }
+    }
+
+    pub(super) fn flush_scheduled_ticks<W: World>(&mut self, world: &mut W) {
+        for (delay, node_id, priority) in self.execution_context.drain_scheduled_ticks() {
+            let Some((pos, _)) = &self.blocks[node_id.index()] else {
+                continue;
+            };
+            world.schedule_tick(*pos, delay as u32, priority);
+        }
+    }
+}

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -40,14 +40,6 @@ impl Nodes {
     pub fn inner(&self) -> &[Node] {
         &self.nodes
     }
-
-    pub fn inner_mut(&mut self) -> &mut [Node] {
-        &mut self.nodes
-    }
-
-    pub fn into_inner(self) -> Box<[Node]> {
-        self.nodes
-    }
 }
 
 impl Index<NodeId> for Nodes {
@@ -155,7 +147,7 @@ pub struct Node {
     pub default_inputs: NodeInput,
     pub side_inputs: NodeInput,
     pub updates: SmallVec<[ForwardLink; 10]>,
-    pub is_io: bool,
+    pub is_frozen: bool,
 
     /// Powered or lit
     pub powered: bool,

--- a/crates/redpiler/src/backend/direct/tick.rs
+++ b/crates/redpiler/src/backend/direct/tick.rs
@@ -18,7 +18,7 @@ impl DirectBackend {
                 } else if !node.powered {
                     if !should_be_powered {
                         schedule_tick(
-                            &mut self.scheduler,
+                            &mut self.execution_context,
                             node_id,
                             node,
                             delay as usize,

--- a/crates/redpiler/src/backend/direct/update.rs
+++ b/crates/redpiler/src/backend/direct/update.rs
@@ -5,8 +5,7 @@ use super::*;
 
 #[inline(always)]
 pub(super) fn update_node(
-    scheduler: &mut TickScheduler,
-    events: &mut Vec<Event>,
+    executioncontext: &mut ExecutionContext,
     nodes: &mut Nodes,
     node_id: NodeId,
 ) {
@@ -34,7 +33,7 @@ pub(super) fn update_node(
                 } else {
                     TickPriority::High
                 };
-                schedule_tick(scheduler, node_id, node, delay as usize, priority);
+                schedule_tick(executioncontext, node_id, node, delay as usize, priority);
             }
         }
         NodeType::Torch => {
@@ -43,7 +42,7 @@ pub(super) fn update_node(
             }
             let should_be_powered = !get_bool_input(node);
             if node.powered != should_be_powered {
-                schedule_tick(scheduler, node_id, node, 1, TickPriority::Normal);
+                schedule_tick(executioncontext, node_id, node, 1, TickPriority::Normal);
             }
         }
         NodeType::Comparator {
@@ -68,14 +67,14 @@ pub(super) fn update_node(
                 } else {
                     TickPriority::Normal
                 };
-                schedule_tick(scheduler, node_id, node, 1, priority);
+                schedule_tick(executioncontext, node_id, node, 1, priority);
             }
         }
         NodeType::Lamp => {
             let should_be_lit = get_bool_input(node);
             let lit = node.powered;
             if lit && !should_be_lit {
-                schedule_tick(scheduler, node_id, node, 2, TickPriority::Normal);
+                schedule_tick(executioncontext, node_id, node, 2, TickPriority::Normal);
             } else if !lit && should_be_lit {
                 set_node(node, true);
             }
@@ -98,7 +97,7 @@ pub(super) fn update_node(
             if node.powered != should_be_powered {
                 set_node(node, should_be_powered);
                 if should_be_powered {
-                    events.push(Event::NoteBlockPlay { noteblock_id });
+                    executioncontext.push_event(Event::NoteBlockPlay { noteblock_id });
                 }
             }
         }

--- a/crates/redpiler/src/backend/mod.rs
+++ b/crates/redpiler/src/backend/mod.rs
@@ -9,6 +9,11 @@ use enum_dispatch::enum_dispatch;
 use mchprs_blocks::BlockPos;
 use mchprs_world::{TickEntry, World};
 
+// JITBackend Lifecycle:
+// 1. compile
+// 2. tick / flush / interactions
+// 3. reset
+// 4. may repeat with 1. again
 #[enum_dispatch]
 pub trait JITBackend {
     fn compile(

--- a/crates/redpiler/src/backend/mod.rs
+++ b/crates/redpiler/src/backend/mod.rs
@@ -33,8 +33,8 @@ pub trait JITBackend {
 
     fn on_use_block(&mut self, pos: BlockPos);
     fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool);
-    fn flush<W: World>(&mut self, world: &mut W, io_only: bool);
-    fn reset<W: World>(&mut self, world: &mut W, io_only: bool);
+    fn flush<W: World>(&mut self, world: &mut W);
+    fn reset<W: World>(&mut self, world: &mut W);
     fn has_pending_ticks(&self) -> bool;
     /// Inspect block for debugging
     fn inspect(&mut self, pos: BlockPos);

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -179,7 +179,7 @@ impl Compiler {
         if self.is_active {
             self.is_active = false;
             if let Some(jit) = &mut self.jit {
-                jit.reset(world, self.options.io_only)
+                jit.reset(world)
             }
         }
 
@@ -222,8 +222,7 @@ impl Compiler {
     }
 
     pub fn flush<W: World>(&mut self, world: &mut W) {
-        let io_only = self.options.io_only;
-        self.backend().flush(world, io_only);
+        self.backend().flush(world);
     }
 
     pub fn inspect(&mut self, pos: BlockPos) {


### PR DESCRIPTION
This PR introduces several optimizations and refactoring improvements to the redpiler backend:

Changes:
  - Optimize flush performance: Track changed nodes in a separate vector to avoid unnecessarly iterating through the entire nodes array during flush operations
  - Extract tick scheduler and the events queue into a dedicated `ExecutionContext` (also contains the new changes vec)
  - Pin compiler options at start of compilation, this prevents the case where we switch io_only mode mid execution, we never used or really suppored this anyways so it should be fine
  - I also saw that the `Node` layout was a bit weird, we were wasting 18 bytes on padding. By reducing the updates inline vec from 10 to 9 entries we save 16 bytes (alternative being, adding 3 entries for free).

The flush optimization reduces overhead by only processing nodes that have actually changed, which should improve performance especially for large redstone circuits.

We also still have the bug where the reset function does not properly sync all components block state.
To further optimze it, I also decided to just skip syncing the comparators block entities as we weren't properly doing is anyways at the moment.
This should probably be addressed in a different PR.