### PR TITLE
Fix axiom schematics crashing the plot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 [workspace.package]
 authors = ["StackDoubleFlow <ojaslandge@gmail.com>"]
 description = "A multithreaded minecraft server built for redstone."
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/MCHPR/MCHPRS"
 keywords = ["minecraft", "server", "redstone"]
 readme = "README.md"

--- a/crates/schematic/src/lib.rs
+++ b/crates/schematic/src/lib.rs
@@ -247,12 +247,18 @@ fn load_schematic_sponge(
 
     let (offset_x, offset_y, offset_z) = match version {
         2 => {
-            let metadata = nbt_as!(&nbt["Metadata"], Value::Compound);
-            (
-                -nbt_as!(metadata["WEOffsetX"], Value::Int),
-                -nbt_as!(metadata["WEOffsetY"], Value::Int),
-                -nbt_as!(metadata["WEOffsetZ"], Value::Int),
-            )
+            // Axiom stores the offset like version 3 but specifies version 2
+            if let Some(offset) = nbt.get("Offset") {
+                let offset_array = nbt_as!(offset, Value::IntArray);
+                (-offset_array[0], -offset_array[1], -offset_array[2])
+            } else {
+                let metadata = nbt_as!(&nbt["Metadata"], Value::Compound);
+                (
+                    -nbt_as!(metadata["WEOffsetX"], Value::Int),
+                    -nbt_as!(metadata["WEOffsetY"], Value::Int),
+                    -nbt_as!(metadata["WEOffsetZ"], Value::Int),
+                )
+            }
         }
         3 => {
             let offset_array = nbt_as!(&nbt["Offset"], Value::IntArray);

--- a/crates/schematic/src/lib.rs
+++ b/crates/schematic/src/lib.rs
@@ -247,24 +247,23 @@ fn load_schematic_sponge(
 
     let (offset_x, offset_y, offset_z) = match version {
         2 => {
-            if let Some(offset) = nbt.get("Offset") {
+            // Older versions of WorldEdit put the offset in Metadata
+            // These offsets are optional but if present all must be present
+            // Its important to check the WEOffset first as both can be present but only the WEOffset is correct
+            if let Some(metadata) = nbt.get("Metadata")
+                && let metadata = nbt_as!(metadata, Value::Compound)
+                && let Some(offset_x) = metadata.get("WEOffsetX")
+            {
+                (
+                    -nbt_as!(offset_x, Value::Int),
+                    -nbt_as!(metadata["WEOffsetY"], Value::Int),
+                    -nbt_as!(metadata["WEOffsetZ"], Value::Int),
+                )
+            } else if let Some(offset) = nbt.get("Offset") {
                 let offset_array = nbt_as!(offset, Value::IntArray);
                 (-offset_array[0], -offset_array[1], -offset_array[2])
             } else {
-                // Older versions of WorldEdit put the offset in Metadata
-                // These offsets are optional but if present all must be present
-                if let Some(metadata) = nbt.get("Metadata")
-                    && let metadata = nbt_as!(metadata, Value::Compound)
-                    && let Some(offset_x) = metadata.get("WEOffsetX")
-                {
-                    (
-                        -nbt_as!(offset_x, Value::Int),
-                        -nbt_as!(metadata["WEOffsetY"], Value::Int),
-                        -nbt_as!(metadata["WEOffsetZ"], Value::Int),
-                    )
-                } else {
-                    (0, 0, 0)
-                }
+                (0, 0, 0)
             }
         }
         3 => {

--- a/crates/schematic/src/lib.rs
+++ b/crates/schematic/src/lib.rs
@@ -247,22 +247,33 @@ fn load_schematic_sponge(
 
     let (offset_x, offset_y, offset_z) = match version {
         2 => {
-            // Axiom stores the offset like version 3 but specifies version 2
             if let Some(offset) = nbt.get("Offset") {
                 let offset_array = nbt_as!(offset, Value::IntArray);
                 (-offset_array[0], -offset_array[1], -offset_array[2])
             } else {
-                let metadata = nbt_as!(&nbt["Metadata"], Value::Compound);
-                (
-                    -nbt_as!(metadata["WEOffsetX"], Value::Int),
-                    -nbt_as!(metadata["WEOffsetY"], Value::Int),
-                    -nbt_as!(metadata["WEOffsetZ"], Value::Int),
-                )
+                // Older versions of WorldEdit put the offset in Metadata
+                // These offsets are optional but if present all must be present
+                if let Some(metadata) = nbt.get("Metadata")
+                    && let metadata = nbt_as!(metadata, Value::Compound)
+                    && let Some(offset_x) = metadata.get("WEOffsetX")
+                {
+                    (
+                        -nbt_as!(offset_x, Value::Int),
+                        -nbt_as!(metadata["WEOffsetY"], Value::Int),
+                        -nbt_as!(metadata["WEOffsetZ"], Value::Int),
+                    )
+                } else {
+                    (0, 0, 0)
+                }
             }
         }
         3 => {
-            let offset_array = nbt_as!(&nbt["Offset"], Value::IntArray);
-            (-offset_array[0], -offset_array[1], -offset_array[2])
+            if let Some(offset_array) = nbt.get("Offset") {
+                let offset_array = nbt_as!(offset_array, Value::IntArray);
+                (-offset_array[0], -offset_array[1], -offset_array[2])
+            } else {
+                (0, 0, 0)
+            }
         }
         _ => unreachable!(),
     };

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2021"


### PR DESCRIPTION
For some reason Axiom uses the version 3 format for the offset but specifies version 2, thus trying to load in a schematic generated by the Axiom mod would crash the plot.

This fixes that by also checking for the Offset property for sponge version 2.