### PR TITLE
More lenient loading of block entities

### DIFF
--- a/crates/blocks/src/block_entities.rs
+++ b/crates/blocks/src/block_entities.rs
@@ -102,8 +102,28 @@ impl BlockEntity {
         let mut inventory = Vec::new();
         for item in slots_nbt {
             let item_compound = nbt_unwrap_val!(item, Value::Compound);
-            let count = nbt_unwrap_val!(item_compound["Count"], Value::Byte);
-            let slot = nbt_unwrap_val!(item_compound["Slot"], Value::Byte);
+            let count = match item_compound
+                .get("Count")
+                .or_else(|| item_compound.get("count"))
+                .unwrap()
+            {
+                Value::Byte(val) => *val,
+                Value::Int(val) => *val as i8,
+                _ => {
+                    return None;
+                }
+            };
+            let slot = match item_compound
+                .get("Slot")
+                .or_else(|| item_compound.get("slot"))
+                .unwrap()
+            {
+                Value::Byte(val) => *val,
+                Value::Int(val) => *val as i8,
+                _ => {
+                    return None;
+                }
+            };
             let namespaced_name = nbt_unwrap_val!(
                 item_compound
                     .get("Id")


### PR DESCRIPTION
I found the plot crashing when `//load`ing schematics I'd saved on ORE and downloaded via schemati. I've made the loading of the block entity nbt data more lenient so that it more leniently handles the format used in the schematic I was trying to load. It was failing before this edit because the field was called `count` rather than `Count` and the type was `Int` rather than `Byte`. I've made a similar change too for the `Slot` field, though it was not that field causing me problems.