### PR TITLE
Improve performance of `Queues::drain_iter`

### DIFF
--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -25,9 +25,7 @@ struct Queues([Vec<NodeId>; TickScheduler::NUM_PRIORITIES]);
 
 impl Queues {
     fn drain_iter(&mut self) -> impl Iterator<Item = NodeId> + '_ {
-        let [q0, q1, q2, q3] = &mut self.0;
-        let [q0, q1, q2, q3] = [q0, q1, q2, q3].map(|q| q.drain(..));
-        q0.chain(q1).chain(q2).chain(q3)
+        self.0.iter_mut().flat_map(|q| q.drain(..))
     }
 }
 


### PR DESCRIPTION
Checking performance using the benchmark I added in #212 shows that performance has improved when compared to `master`:

```
time:   [250.53 µs 251.09 µs 251.69 µs]
change: [-1.8127% -1.3880% -1.0153%] (p = 0.00 < 0.05)
Performance has improved.
```

Godbolt: https://godbolt.org/z/f8W6v9fdo