### PR TITLE
Interleaved forward links

### DIFF
--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -186,7 +186,7 @@ pub fn compile(
         } else {
             graph.neighbors_directed(node, Outgoing).count()
         };
-        let extra_nodes = (outgoing + 15 - 5) / 16;
+        let extra_nodes = Node::forward_link_blocks_for(outgoing);
         nodes_len += 1 + extra_nodes;
 
         let block = graph[node].block.map(|(pos, id)| (pos, Block::from_id(id)));

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -132,7 +132,7 @@ fn compile_node(
     let forward_links = &forward_links[fwd_link_begin as usize..fwd_link_end as usize];
     let fwd_link_len = forward_links.len();
     assert!(fwd_link_len < u16::MAX as usize);
-    
+
     // Safety: These are simply placeholder values and should not ever be read
     let mut first_links = [ForwardLink::new(unsafe { NodeId::from_index(0) }, false, 0); 5];
     let num_first = fwd_link_len.min(first_links.len());
@@ -173,7 +173,6 @@ pub fn compile(
     options: &CompilerOptions,
     _monitor: Arc<TaskMonitor>,
 ) {
-
     backend.blocks = Vec::with_capacity(graph.node_count());
 
     // Create a mapping from compile to backend node indices
@@ -182,10 +181,13 @@ pub fn compile(
     for node in graph.node_indices() {
         nodes_map.insert(node, nodes_len);
 
-        let outgoing = if graph[node].ty == crate::compile_graph::NodeType::Constant {0} else {graph.neighbors_directed(node, Outgoing).count()};
+        let outgoing = if graph[node].ty == crate::compile_graph::NodeType::Constant {
+            0
+        } else {
+            graph.neighbors_directed(node, Outgoing).count()
+        };
         let extra_nodes = (outgoing + 15 - 5) / 16;
         nodes_len += 1 + extra_nodes;
-
 
         let block = graph[node].block.map(|(pos, id)| (pos, Block::from_id(id)));
         backend.blocks.push(block);
@@ -207,15 +209,14 @@ pub fn compile(
             &mut backend.noteblock_info,
             &mut backend.forward_links,
             &mut stats,
-            &mut nodes
+            &mut nodes,
         );
     }
     stats.nodes_bytes = nodes_len * std::mem::size_of::<Node>();
     trace!("{:#?}", stats);
 
+    assert_eq!(nodes.len(), nodes_len);
 
-    assert_eq!(nodes.len(), nodes_len);        
-    
     backend.nodes = Nodes::new(nodes.into_boxed_slice());
 
     // Create a mapping from block pos to backend NodeId

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -73,7 +73,7 @@ fn compile_node(
     side_inputs.ss_counts[0] += (MAX_INPUTS - side_input_count) as u8;
 
     use crate::compile_graph::NodeType as CNodeType;
-    let fwd_link_begin = forward_links.len();
+    let fwd_link_begin = forward_links.len() as u32;
     if node.ty != CNodeType::Constant {
         let new_links = graph
             .edges_directed(node_idx, Direction::Outgoing)
@@ -93,8 +93,8 @@ fn compile_node(
             });
         forward_links.extend(new_links);
     };
-    let fwd_link_end = forward_links.len();
-    stats.update_link_count += fwd_link_end - fwd_link_begin;
+    let fwd_link_end = forward_links.len() as u32;
+    stats.update_link_count += (fwd_link_end - fwd_link_begin) as usize;
 
     let ty = match &node.ty {
         CNodeType::Repeater {

--- a/crates/redpiler/src/backend/direct/compile.rs
+++ b/crates/redpiler/src/backend/direct/compile.rs
@@ -5,7 +5,7 @@ use mchprs_blocks::blocks::{Block, Instrument};
 use mchprs_blocks::BlockPos;
 use mchprs_world::TickEntry;
 use petgraph::visit::EdgeRef;
-use petgraph::Direction;
+use petgraph::Direction::{self, Outgoing};
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use tracing::trace;
@@ -29,7 +29,8 @@ fn compile_node(
     noteblock_info: &mut Vec<(BlockPos, Instrument, u8)>,
     forward_links: &mut Vec<ForwardLink>,
     stats: &mut FinalGraphStats,
-) -> Node {
+    out_nodes: &mut Vec<Node>,
+) {
     let node = &graph[node_idx];
 
     const MAX_INPUTS: usize = 255;
@@ -128,19 +129,64 @@ fn compile_node(
         }
     };
 
-    Node {
+    let forward_links = &forward_links[fwd_link_begin as usize..fwd_link_end as usize];
+    let fwd_link_len = forward_links.len();
+    assert!(fwd_link_len < u16::MAX as usize);
+    
+    let mut first_links = [ForwardLink::new(unsafe { NodeId::from_index(0) }, false, 0); 5];
+    let num_first = fwd_link_len.min(first_links.len());
+    first_links[..num_first].copy_from_slice(&forward_links[..num_first]);
+
+    let node = Node {
         ty,
         default_inputs,
         side_inputs,
-        fwd_link_begin,
-        fwd_link_end,
+        fwd_link_len: fwd_link_len as u16,
         powered: node.state.powered,
         output_power: node.state.output_strength,
         locked: node.state.repeater_locked,
         pending_tick: false,
         changed: false,
         is_io: node.is_input || node.is_output,
+        fwd_links: first_links,
+    };
+    let out_i = out_nodes.len();
+    out_nodes.push(node);
+
+    let skip = (fwd_link_len + 15 - 5) / 16;
+
+    const BLOCK_SIZE: usize = std::mem::size_of::<Node>() / std::mem::size_of::<ForwardLink>();
+
+    let mut num_chunks = 0;
+    for chunk in forward_links[num_first..].chunks(BLOCK_SIZE) {
+        let mut block = [
+            ForwardLink::new(unsafe { NodeId::from_index(0) }, false, 0);
+            BLOCK_SIZE
+        ];
+        block[..chunk.len()].copy_from_slice(chunk);
+
+        // println!("{:?}", chunk);
+
+        out_nodes.push(unsafe {
+            std::mem::transmute(block)
+        });
+        num_chunks += 1;
     }
+
+    let source: &[ForwardLink] = unsafe {std::slice::from_raw_parts(
+        forward_links.as_ptr(),
+        fwd_link_len as usize
+    )};
+    
+    let node = &mut out_nodes[out_i];
+    let target: &mut [ForwardLink] = unsafe {std::slice::from_raw_parts_mut(
+        node.fwd_links.as_mut_ptr(),
+        fwd_link_len as usize
+    )};
+
+    target.copy_from_slice(source);
+
+    assert_eq!(skip, num_chunks)
 }
 
 pub fn compile(
@@ -150,40 +196,67 @@ pub fn compile(
     options: &CompilerOptions,
     _monitor: Arc<TaskMonitor>,
 ) {
+
+    backend.blocks = Vec::with_capacity(graph.node_count());
+
     // Create a mapping from compile to backend node indices
     let mut nodes_map = FxHashMap::with_capacity_and_hasher(graph.node_count(), Default::default());
+    let mut nodes_len = 0;
     for node in graph.node_indices() {
-        nodes_map.insert(node, nodes_map.len());
+        nodes_map.insert(node, nodes_len);
+
+        let outgoing = if graph[node].ty == crate::compile_graph::NodeType::Constant {0} else {graph.neighbors_directed(node, Outgoing).count()};
+        let extra_nodes = (outgoing + 15 - 5) / 16;
+        nodes_len += 1 + extra_nodes;
+
+
+        let block = graph[node].block.map(|(pos, id)| (pos, Block::from_id(id)));
+        backend.blocks.push(block);
+
+        for _ in 0..extra_nodes {
+            backend.blocks.push(Some((BlockPos::zero(), Block::Air {  })));
+        }
     }
-    let nodes_len = nodes_map.len();
 
     // Lower nodes
     let mut stats = FinalGraphStats::default();
-    let nodes = graph
-        .node_indices()
-        .map(|idx| {
-            compile_node(
-                &graph,
-                idx,
-                nodes_len,
-                &nodes_map,
-                &mut backend.noteblock_info,
-                &mut backend.forward_links,
-                &mut stats,
-            )
-        })
-        .collect();
+    let mut nodes = Vec::new();
+    for idx in graph.node_indices() {
+        compile_node(
+            &graph,
+            idx,
+            nodes_len,
+            &nodes_map,
+            &mut backend.noteblock_info,
+            &mut backend.forward_links,
+            &mut stats,
+            &mut nodes
+        );
+    }
     stats.nodes_bytes = nodes_len * std::mem::size_of::<Node>();
     trace!("{:#?}", stats);
 
-    backend.blocks = graph
-        .node_weights()
-        .map(|node| node.block.map(|(pos, id)| (pos, Block::from_id(id))))
-        .collect();
-    backend.nodes = Nodes::new(nodes);
+
+    assert_eq!(nodes.len(), nodes_len);
+
+    // backend.blocks = graph
+    //     .node_weights()
+    //     .map(|node| node.block.map(|(pos, id)| (pos, Block::from_id(id))))
+    //     .collect();
+    backend.nodes = Nodes::new(nodes.into_boxed_slice());
+
+    assert_eq!(backend.nodes.nodes.len(), backend.blocks.len());
+
+    let mut skip = 0;
 
     // Create a mapping from block pos to backend NodeId
     for i in 0..backend.blocks.len() {
+        if skip > 0 {
+            skip -= 1;
+            continue;
+        }
+        let node = &backend.nodes[backend.nodes.get(i)];
+        skip = (node.fwd_link_len + 15 - 5) / 16;
         if let Some((pos, _)) = backend.blocks[i] {
             backend.pos_map.insert(pos, backend.nodes.get(i));
         }

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -114,7 +114,6 @@ enum Event {
 #[derive(Default)]
 pub struct DirectBackend {
     nodes: Nodes,
-    forward_links: Vec<ForwardLink>,
     blocks: Vec<Option<(BlockPos, Block)>>,
     pos_map: FxHashMap<BlockPos, NodeId>,
     scheduler: TickScheduler,
@@ -209,7 +208,6 @@ impl JITBackend for DirectBackend {
             }
         }
 
-        self.forward_links.clear();
         self.pos_map.clear();
         self.noteblock_info.clear();
         self.events.clear();

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -137,6 +137,8 @@ impl DirectBackend {
         
         let node = &self.nodes[node_id];
 
+        // Safety: node is followed by the correct number of ForwardLink blocks
+        // Safety: node.fwd_links and node.fwd_link_len are not modified for links's lifetime
         let links: &[ForwardLink] = unsafe {std::slice::from_raw_parts(
             node.fwd_links.as_ptr(),
             node.fwd_link_len as usize
@@ -192,8 +194,8 @@ impl JITBackend for DirectBackend {
 
         let nodes = std::mem::take(&mut self.nodes);
 
-        for (i, node) in nodes.into_inner().iter().enumerate() {
-            let Some((pos, block)) = self.blocks[i] else {
+        for (i, node) in nodes.enumerate() {
+            let Some((pos, block)) = self.blocks[i.index()] else {
                 continue;
             };
             if matches!(node.ty, NodeType::Comparator { .. }) {
@@ -262,17 +264,9 @@ impl JITBackend for DirectBackend {
                 }
             }
         }
-        let mut skip = 0;
 
-        for (i, node) in self.nodes.inner_mut().iter_mut().enumerate() {
-            if skip > 0 {
-                skip -= 1;
-                continue;
-            }
-            
-            skip = (node.fwd_link_len + 15 - 5) / 16;
-
-            let Some((pos, block)) = &mut self.blocks[i] else {
+        for (i, node) in self.nodes.enumerate_mut() {
+            let Some((pos, block)) = &mut self.blocks[i.index()] else {
                 continue;
             };
             if node.changed && (!io_only || node.is_io) {
@@ -374,7 +368,7 @@ fn calculate_comparator_output(mode: ComparatorMode, input_strength: u8, power_o
 impl fmt::Display for DirectBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "digraph {{")?;
-        for (id, node) in self.nodes.inner().iter().enumerate() {
+        for (id, node) in self.nodes.enumerate() {
             if matches!(node.ty, NodeType::Wire) {
                 continue;
             }
@@ -397,26 +391,21 @@ impl fmt::Display for DirectBackend {
                 NodeType::Constant => format!("Constant({})", node.output_power),
                 NodeType::NoteBlock { .. } => "NoteBlock".to_string(),
             };
-            let pos = if let Some((pos, _)) = self.blocks[id] {
+            let pos = if let Some((pos, _)) = self.blocks[id.index()] {
                 format!("{}, {}, {}", pos.x, pos.y, pos.z)
             } else {
                 "No Pos".to_string()
             };
-            writeln!(f, "    n{} [ label = \"{}\\n({})\" ];", id, label, pos)?;
+            writeln!(f, "    n{} [ label = \"{}\\n({})\" ];", id.index(), label, pos)?;
 
-            let links: &[ForwardLink] = unsafe {std::slice::from_raw_parts(
-                node.fwd_links.as_ptr(),
-                node.fwd_link_len as usize
-            )};
-
-            for link in links {
+            for link in self.nodes.forward_link(id) {
                 let out_index = link.node().index();
                 let distance = link.ss();
                 let color = if link.side() { ",color=\"blue\"" } else { "" };
                 writeln!(
                     f,
                     "    n{} -> n{} [ label = \"{}\"{} ];",
-                    id, out_index, distance, color
+                    id.index(), out_index, distance, color
                 )?;
             }
         }

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -36,7 +36,7 @@ impl Queues {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct TickScheduler {
     queues_deque: [Queues; Self::NUM_QUEUES],
     pos: usize,
@@ -107,11 +107,12 @@ impl TickScheduler {
     }
 }
 
+#[derive(Clone)]
 enum Event {
     NoteBlockPlay { noteblock_id: u16 },
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct DirectBackend {
     nodes: Nodes,
     blocks: Vec<Option<(BlockPos, Block)>>,

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -135,7 +135,11 @@ impl DirectBackend {
         node.powered = powered;
         node.output_power = new_power;
 
-        for forward_link in &self.forward_links[node.fwd_link_begin as usize..node.fwd_link_end as usize] {
+        // Safety: range is guaranteed to be within bounds in DirectBackend::compile_node
+        for forward_link in unsafe {
+            self.forward_links
+                .get_unchecked(node.fwd_link_begin as usize..node.fwd_link_end as usize)
+        } {
             let side = forward_link.side();
             let distance = forward_link.ss();
             let update = forward_link.node();
@@ -387,7 +391,9 @@ impl fmt::Display for DirectBackend {
                 "No Pos".to_string()
             };
             writeln!(f, "    n{} [ label = \"{}\\n({})\" ];", id, label, pos)?;
-            for link in &self.forward_links[node.fwd_link_begin as usize..node.fwd_link_end as usize] {
+            for link in
+                &self.forward_links[node.fwd_link_begin as usize..node.fwd_link_end as usize]
+            {
                 let out_index = link.node().index();
                 let distance = link.ss();
                 let color = if link.side() { ",color=\"blue\"" } else { "" };

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -134,12 +134,15 @@ impl DirectBackend {
         node.changed = true;
         node.powered = powered;
         node.output_power = new_power;
+        
+        let node = &self.nodes[node_id];
 
-        // Safety: range is guaranteed to be within bounds in DirectBackend::compile_node
-        for forward_link in unsafe {
-            self.forward_links
-                .get_unchecked(node.fwd_link_begin as usize..node.fwd_link_end as usize)
-        } {
+        let links: &[ForwardLink] = unsafe {std::slice::from_raw_parts(
+            node.fwd_links.as_ptr(),
+            node.fwd_link_len as usize
+        )};
+
+        for forward_link in links {
             let side = forward_link.side();
             let distance = forward_link.ss();
             let update = forward_link.node();
@@ -259,7 +262,16 @@ impl JITBackend for DirectBackend {
                 }
             }
         }
+        let mut skip = 0;
+
         for (i, node) in self.nodes.inner_mut().iter_mut().enumerate() {
+            if skip > 0 {
+                skip -= 1;
+                continue;
+            }
+            
+            skip = (node.fwd_link_len + 15 - 5) / 16;
+
             let Some((pos, block)) = &mut self.blocks[i] else {
                 continue;
             };
@@ -391,9 +403,13 @@ impl fmt::Display for DirectBackend {
                 "No Pos".to_string()
             };
             writeln!(f, "    n{} [ label = \"{}\\n({})\" ];", id, label, pos)?;
-            for link in
-                &self.forward_links[node.fwd_link_begin as usize..node.fwd_link_end as usize]
-            {
+
+            let links: &[ForwardLink] = unsafe {std::slice::from_raw_parts(
+                node.fwd_links.as_ptr(),
+                node.fwd_link_len as usize
+            )};
+
+            for link in links {
                 let out_index = link.node().index();
                 let distance = link.ss();
                 let color = if link.side() { ",color=\"blue\"" } else { "" };

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -135,7 +135,7 @@ impl DirectBackend {
         node.powered = powered;
         node.output_power = new_power;
 
-        for forward_link in &self.forward_links[node.fwd_link_begin..node.fwd_link_end] {
+        for forward_link in &self.forward_links[node.fwd_link_begin as usize..node.fwd_link_end as usize] {
             let side = forward_link.side();
             let distance = forward_link.ss();
             let update = forward_link.node();
@@ -387,7 +387,7 @@ impl fmt::Display for DirectBackend {
                 "No Pos".to_string()
             };
             writeln!(f, "    n{} [ label = \"{}\\n({})\" ];", id, label, pos)?;
-            for link in &self.forward_links[node.fwd_link_begin..node.fwd_link_end] {
+            for link in &self.forward_links[node.fwd_link_begin as usize..node.fwd_link_end as usize] {
                 let out_index = link.node().index();
                 let distance = link.ss();
                 let color = if link.side() { ",color=\"blue\"" } else { "" };

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -134,15 +134,14 @@ impl DirectBackend {
         node.changed = true;
         node.powered = powered;
         node.output_power = new_power;
-        
+
         let node = &self.nodes[node_id];
 
         // Safety: node is followed by the correct number of ForwardLink blocks
         // Safety: node.fwd_links and node.fwd_link_len are not modified for links's lifetime
-        let links: &[ForwardLink] = unsafe {std::slice::from_raw_parts(
-            node.fwd_links.as_ptr(),
-            node.fwd_link_len as usize
-        )};
+        let links: &[ForwardLink] = unsafe {
+            std::slice::from_raw_parts(node.fwd_links.as_ptr(), node.fwd_link_len as usize)
+        };
 
         for forward_link in links {
             let side = forward_link.side();
@@ -396,7 +395,13 @@ impl fmt::Display for DirectBackend {
             } else {
                 "No Pos".to_string()
             };
-            writeln!(f, "    n{} [ label = \"{}\\n({})\" ];", id.index(), label, pos)?;
+            writeln!(
+                f,
+                "    n{} [ label = \"{}\\n({})\" ];",
+                id.index(),
+                label,
+                pos
+            )?;
 
             for link in self.nodes.forward_link(id) {
                 let out_index = link.node().index();
@@ -405,7 +410,10 @@ impl fmt::Display for DirectBackend {
                 writeln!(
                     f,
                     "    n{} -> n{} [ label = \"{}\"{} ];",
-                    id.index(), out_index, distance, color
+                    id.index(),
+                    out_index,
+                    distance,
+                    color
                 )?;
             }
         }

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -226,23 +226,26 @@ pub struct Node {
     pub fwd_links: LinkBuffer,
 }
 
-type LinkBuffer = [ForwardLink; 5];
+const LINKS_IN_NODE: usize = 5;
+type LinkBuffer = [ForwardLink; LINKS_IN_NODE];
 
 impl Node {
-    #[inline(always)]
-    pub fn forward_link_blocks(&self) -> usize {
-        const BLOCK_SIZE: usize = std::mem::size_of::<Node>() / std::mem::size_of::<ForwardLink>();
+    pub fn forward_link_blocks_for(fwd_link_len: usize) -> usize {
+        const BLOCK_SIZE: usize = size_of::<Node>() / size_of::<ForwardLink>();
 
         const {
-            assert!(std::mem::size_of::<Node>() % std::mem::size_of::<ForwardLink>() == 0);
-            assert!(std::mem::align_of::<Node>() % std::mem::align_of::<ForwardLink>() == 0);
-            assert!(
-                std::mem::offset_of!(Node, fwd_links) + std::mem::size_of::<LinkBuffer>()
-                    == std::mem::size_of::<Node>()
-            )
+            use std::mem::offset_of;
+
+            assert!(size_of::<Node>() % size_of::<ForwardLink>() == 0);
+            assert!(align_of::<Node>() % align_of::<ForwardLink>() == 0);
+            assert!(offset_of!(Node, fwd_links) + size_of::<LinkBuffer>() == size_of::<Node>())
         }
 
-        (self.fwd_link_len as usize + BLOCK_SIZE - 1 - self.fwd_links.len()) / BLOCK_SIZE
+        (fwd_link_len as usize + BLOCK_SIZE - 1 - LINKS_IN_NODE) / BLOCK_SIZE
+    }
+
+    pub fn forward_link_blocks(&self) -> usize {
+        Node::forward_link_blocks_for(self.fwd_link_len as usize)
     }
 
     /// Safety: self must be followed by correct number of forward links

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -36,7 +36,7 @@ impl Nodes {
             // Safety: bounds checked and invalid indices skipped over
             let id = unsafe { NodeId::from_index(i) };
             let node = &nodes[i];
-            
+
             valid[i] = true;
             ids.push(id);
 
@@ -74,15 +74,13 @@ impl Nodes {
     }
 
     pub fn enumerate(&self) -> impl Iterator<Item = (NodeId, &Node)> {
-        self.ids.iter().copied().map(|id| {
-            (id, &self[id])
-        })
+        self.ids.iter().copied().map(|id| (id, &self[id]))
     }
 
     pub fn enumerate_mut(&mut self) -> impl Iterator<Item = (NodeId, &mut Node)> {
         self.ids.iter().copied().map(|id| {
             // Safety: only unique references are returned and id comes from self
-            (id, unsafe {&mut *self.nodes.as_mut_ptr().add(id.index())})
+            (id, unsafe { &mut *self.nodes.as_mut_ptr().add(id.index()) })
         })
     }
 }

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -160,9 +160,9 @@ pub struct Node {
     pub side_inputs: NodeInput,
 
     /// The index to the first forward link of this node.
-    pub fwd_link_begin: usize,
+    pub fwd_link_begin: u32,
     /// The index to after the last forward link of this node.
-    pub fwd_link_end: usize,
+    pub fwd_link_end: u32,
 
     pub is_io: bool,
 

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -32,7 +32,7 @@ impl Nodes {
         if self.nodes.get(idx).is_some() {
             NodeId(idx as u32)
         } else {
-            panic!("node index out of bounds: {}", idx)
+            panic!("node index out of bounds: {}, len={}", idx, self.nodes.len())
         }
     }
 
@@ -152,17 +152,17 @@ impl NonMaxU8 {
 // size as an L1 cache line on most modern processors. By forcing a 64-byte
 // alignment, we make sure that the entire `Node` can fit on one cache line,
 // preventing scenarios where we have to fetch 2 cache lines to read a single `Node`.
-#[repr(align(64))]
+#[repr(C, align(64))]
 #[derive(Debug, Clone)]
 pub struct Node {
-    pub ty: NodeType,
     pub default_inputs: NodeInput,
     pub side_inputs: NodeInput,
-
     /// The index to the first forward link of this node.
-    pub fwd_link_begin: u32,
-    /// The index to after the last forward link of this node.
-    pub fwd_link_end: u32,
+    pub ty: NodeType,
+
+    pub fwd_link_len: u16,
+
+    pub output_power: u8,
 
     pub is_io: bool,
 
@@ -170,7 +170,8 @@ pub struct Node {
     pub powered: bool,
     /// Only for repeaters
     pub locked: bool,
-    pub output_power: u8,
     pub changed: bool,
     pub pending_tick: bool,
+
+    pub fwd_links: [ForwardLink; 5],
 }

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -240,7 +240,7 @@ impl Node {
             assert!(offset_of!(Node, fwd_links) + size_of::<LinkBuffer>() == size_of::<Node>())
         }
 
-        (fwd_link_len + BLOCK_SIZE - 1 - LINKS_IN_NODE) / BLOCK_SIZE
+        fwd_link_len.saturating_sub(LINKS_IN_NODE).div_ceil(BLOCK_SIZE)
     }
 
     pub fn forward_link_blocks(&self) -> usize {

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -240,7 +240,9 @@ impl Node {
             assert!(offset_of!(Node, fwd_links) + size_of::<LinkBuffer>() == size_of::<Node>())
         }
 
-        fwd_link_len.saturating_sub(LINKS_IN_NODE).div_ceil(BLOCK_SIZE)
+        fwd_link_len
+            .saturating_sub(LINKS_IN_NODE)
+            .div_ceil(BLOCK_SIZE)
     }
 
     pub fn forward_link_blocks(&self) -> usize {

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -206,7 +206,6 @@ impl NonMaxU8 {
 pub struct Node {
     pub default_inputs: NodeInput,
     pub side_inputs: NodeInput,
-    /// The index to the first forward link of this node.
     pub ty: NodeType,
 
     pub fwd_link_len: u16,

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -19,7 +19,7 @@ impl NodeId {
 
 // This is Pretty Bad:tm: because one can create a NodeId using another instance of Nodes,
 // but at least some type system protection is better than none.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Nodes {
     nodes: Box<[Node]>,
     valid: Box<[bool]>,

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -241,7 +241,7 @@ impl Node {
             assert!(offset_of!(Node, fwd_links) + size_of::<LinkBuffer>() == size_of::<Node>())
         }
 
-        (fwd_link_len as usize + BLOCK_SIZE - 1 - LINKS_IN_NODE) / BLOCK_SIZE
+        (fwd_link_len + BLOCK_SIZE - 1 - LINKS_IN_NODE) / BLOCK_SIZE
     }
 
     pub fn forward_link_blocks(&self) -> usize {

--- a/crates/redpiler/src/backend/mod.rs
+++ b/crates/redpiler/src/backend/mod.rs
@@ -38,6 +38,7 @@ pub trait JITBackend {
 use direct::DirectBackend;
 
 #[enum_dispatch(JITBackend)]
+#[derive(Clone)]
 pub enum BackendDispatcher {
     DirectBackend,
 }

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -111,7 +111,7 @@ impl CompilerOptions {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Compiler {
     is_active: bool,
     backend: Option<BackendDispatcher>,


### PR DESCRIPTION
This put the forwards links at the end of Node, when the forward links don't fit into the Node extra nodes will simply be inserted which will be skipped over when iterating.
This results in not having to go to a separate area in memory when looking up the forward links and not even having to load in an extra cache-line when there are less than 6 forward links.
This does have the disadvantage of making iterating a bit more complicated.
Additionally this requires unsafe and is a bit error prone, I tried to minimize potential error by minimizing magic numbers and putting in asserts.

Benchmarks:
rtps for `tickn(50_000)` with `1000` samples for iris mandlebrot benchmark (ran twice in a row):
From this we can see about a 5.6% speedup.

master (https://github.com/MCHPR/MCHPRS/tree/a179ab1be44dd44fa3f20ba67195a7f147ab06f2)
```
avg= 3259104 dev=   31748 q0= 3100066 q1= 3241976 q2= 3246659 q3= 3291493 q4= 3302341
avg= 3252497 dev=   26361 q0= 3098181 q1= 3228507 q2= 3248133 q3= 3278679 q4= 3304033
```

old (https://github.com/BramOtte/MCHPRS/tree/refactor-forward-links-unsafe):
(this seems to be within margin of error from master)
```
avg= 3274858 dev=   29929 q0= 2998197 q1= 3274732 q2= 3281709 q3= 3284870 q4= 3352242
avg= 3280807 dev=   27363 q0= 3156344 q1= 3279137 q2= 3283034 q3= 3286403 q4= 3349798
```

This PR:
```
avg= 3459374 dev=   15655 q0= 3297415 q1= 3455197 q2= 3459280 q3= 3463341 q4= 3483251
avg= 3465641 dev=   20777 q0= 3198885 q1= 3457385 q2= 3473685 q3= 3478063 q4= 3482424
```