### PR TITLE
Make the `InputSearch` pass faster by caching queried blocks

### DIFF
--- a/crates/redpiler/src/passes/input_search.rs
+++ b/crates/redpiler/src/passes/input_search.rs
@@ -334,7 +334,7 @@ fn is_wire(world: &impl World, pos: BlockPos) -> bool {
 
 fn provides_weak_power(block: Block, side: BlockFace) -> bool {
     match block {
-        Block::RedstoneTorch { .. } => true,
+        Block::RedstoneTorch { .. } => side != BlockFace::Top,
         Block::RedstoneWallTorch { facing, .. } if facing.block_face() != side => true,
         Block::RedstoneBlock {} => true,
         Block::Lever { .. } => true,

--- a/crates/redpiler/src/passes/input_search.rs
+++ b/crates/redpiler/src/passes/input_search.rs
@@ -13,7 +13,6 @@ use mchprs_redstone::{self, comparator, wire};
 use mchprs_world::World;
 use petgraph::visit::NodeIndexable;
 use rustc_hash::FxHashMap;
-use std::collections::VecDeque;
 
 pub struct InputSearch;
 
@@ -139,20 +138,20 @@ impl<'a, W: World> InputSearchState<'a, W> {
         start_node: NodeIdx,
         root_pos: BlockPos,
         link_ty: LinkType,
-        mut distance: u8,
+        initial_distance: u8,
     ) {
-        let mut queue: VecDeque<BlockPos> = VecDeque::new();
-        let mut discovered = FxHashMap::default();
+        let mut discovered = vec![(root_pos, initial_distance)];
 
-        discovered.insert(root_pos, distance);
-        queue.push_back(root_pos);
+        let has_been_discovered =
+            |discovered: &[_], new_pos| discovered.iter().any(|(pos, _)| *pos == new_pos);
 
-        while !queue.is_empty() {
-            let pos = queue.pop_front().unwrap();
-            distance = discovered[&pos];
+        let mut idx = 0;
+        while idx < discovered.len() {
+            let (pos, distance) = discovered[idx];
+            idx += 1;
 
-            // We can stop looking once we've reached the max ss of a wire. This also prevents
-            // overflowing the distance past 255
+            // We can stop looking once we've reached the max ss of a wire.
+            // This also prevents overflowing the distance past 255.
             if distance > 15 {
                 continue;
             }
@@ -175,29 +174,28 @@ impl<'a, W: World> InputSearchState<'a, W> {
                     false,
                 );
 
-                if is_wire(self.world, neighbor_pos) && !discovered.contains_key(&neighbor_pos) {
-                    queue.push_back(neighbor_pos);
-                    discovered.insert(neighbor_pos, discovered[&pos] + 1);
+                if is_wire(self.world, neighbor_pos)
+                    && !has_been_discovered(&discovered, neighbor_pos)
+                {
+                    discovered.push((neighbor_pos, distance + 1));
                 }
 
                 if side.is_horizontal() {
                     if !up_block.is_solid() && !neighbor.is_transparent() {
                         let neighbor_up_pos = neighbor_pos.offset(BlockFace::Top);
                         if is_wire(self.world, neighbor_up_pos)
-                            && !discovered.contains_key(&neighbor_up_pos)
+                            && !has_been_discovered(&discovered, neighbor_up_pos)
                         {
-                            queue.push_back(neighbor_up_pos);
-                            discovered.insert(neighbor_up_pos, discovered[&pos] + 1);
+                            discovered.push((neighbor_up_pos, distance + 1));
                         }
                     }
 
                     if !neighbor.is_solid() {
                         let neighbor_down_pos = neighbor_pos.offset(BlockFace::Bottom);
                         if is_wire(self.world, neighbor_down_pos)
-                            && !discovered.contains_key(&neighbor_down_pos)
+                            && !has_been_discovered(&discovered, neighbor_down_pos)
                         {
-                            queue.push_back(neighbor_down_pos);
-                            discovered.insert(neighbor_down_pos, discovered[&pos] + 1);
+                            discovered.push((neighbor_down_pos, distance + 1));
                         }
                     }
                 }

--- a/crates/redpiler/src/passes/input_search.rs
+++ b/crates/redpiler/src/passes/input_search.rs
@@ -38,10 +38,42 @@ impl<W: World> Pass<W> for InputSearch {
     }
 }
 
+/// Querying blocks from the world may be expensive, so we save recently
+/// queried blocks in a cache to reduce the number of times we query the world.
+struct BlockLookupCache<'world, W: World> {
+    world: &'world W,
+    cache: [[[Option<(Block, BlockPos)>; 16]; 16]; 16],
+}
+
+impl<'world, W: World> BlockLookupCache<'world, W> {
+    pub fn new(world: &'world W) -> Self {
+        Self {
+            world,
+            cache: Default::default(),
+        }
+    }
+
+    fn get_block(&mut self, pos: BlockPos) -> Block {
+        let cache_x = pos.x as usize % 16;
+        let cache_y = pos.y as usize % 16;
+        let cache_z = pos.z as usize % 16;
+        let cache_entry = &mut self.cache[cache_x][cache_y][cache_z];
+        match cache_entry {
+            Some((block, block_pos)) if *block_pos == pos => *block,
+            _ => {
+                let block = self.world.get_block(pos);
+                *cache_entry = Some((block, pos));
+                block
+            }
+        }
+    }
+}
+
 struct InputSearchState<'a, W: World> {
     world: &'a W,
     graph: &'a mut CompileGraph,
     pos_map: FxHashMap<BlockPos, NodeIdx>,
+    block_lookup_cache: BlockLookupCache<'a, W>,
 }
 
 impl<'a, W: World> InputSearchState<'a, W> {
@@ -56,6 +88,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
             world,
             graph,
             pos_map,
+            block_lookup_cache: BlockLookupCache::new(world),
         }
     }
 
@@ -74,7 +107,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
         if block.is_solid() {
             for side in &BlockFace::values() {
                 let pos = pos.offset(*side);
-                let block = self.world.get_block(pos);
+                let block = self.block_lookup_cache.get_block(pos);
                 if provides_strong_power(block, *side) {
                     self.graph.add_edge(
                         self.pos_map[&pos],
@@ -142,6 +175,8 @@ impl<'a, W: World> InputSearchState<'a, W> {
     ) {
         let mut discovered = vec![(root_pos, initial_distance)];
 
+        // Linear search has better runtime performance than any other lookup when there are
+        // only a few elements, which is most of the time.
         let has_been_discovered =
             |discovered: &[_], new_pos| discovered.iter().any(|(pos, _)| *pos == new_pos);
 
@@ -158,11 +193,11 @@ impl<'a, W: World> InputSearchState<'a, W> {
 
             // The block above the wire. If it's solid, we can't connect up diagonally
             let up_pos = pos.offset(BlockFace::Top);
-            let up_block = self.world.get_block(up_pos);
+            let up_block = self.block_lookup_cache.get_block(up_pos);
 
             for side in &BlockFace::values() {
                 let neighbor_pos = pos.offset(*side);
-                let neighbor = self.world.get_block(neighbor_pos);
+                let neighbor = self.block_lookup_cache.get_block(neighbor_pos);
 
                 self.get_redstone_links(
                     neighbor,
@@ -174,16 +209,14 @@ impl<'a, W: World> InputSearchState<'a, W> {
                     false,
                 );
 
-                if is_wire(self.world, neighbor_pos)
-                    && !has_been_discovered(&discovered, neighbor_pos)
-                {
+                if is_wire(neighbor) && !has_been_discovered(&discovered, neighbor_pos) {
                     discovered.push((neighbor_pos, distance + 1));
                 }
 
                 if side.is_horizontal() {
                     if !up_block.is_solid() && !neighbor.is_transparent() {
                         let neighbor_up_pos = neighbor_pos.offset(BlockFace::Top);
-                        if is_wire(self.world, neighbor_up_pos)
+                        if is_wire(self.block_lookup_cache.get_block(neighbor_up_pos))
                             && !has_been_discovered(&discovered, neighbor_up_pos)
                         {
                             discovered.push((neighbor_up_pos, distance + 1));
@@ -192,7 +225,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
 
                     if !neighbor.is_solid() {
                         let neighbor_down_pos = neighbor_pos.offset(BlockFace::Bottom);
-                        if is_wire(self.world, neighbor_down_pos)
+                        if is_wire(self.block_lookup_cache.get_block(neighbor_down_pos))
                             && !has_been_discovered(&discovered, neighbor_down_pos)
                         {
                             discovered.push((neighbor_down_pos, distance + 1));
@@ -205,7 +238,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
 
     fn search_diode_inputs(&mut self, id: NodeIdx, pos: BlockPos, facing: BlockDirection) {
         let input_pos = pos.offset(facing.block_face());
-        let input_block = self.world.get_block(input_pos);
+        let input_block = self.block_lookup_cache.get_block(input_pos);
         self.get_redstone_links(
             input_block,
             facing.block_face(),
@@ -219,7 +252,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
 
     fn search_repeater_side(&mut self, id: NodeIdx, pos: BlockPos, side: BlockDirection) {
         let side_pos = pos.offset(side.block_face());
-        let side_block = self.world.get_block(side_pos);
+        let side_block = self.block_lookup_cache.get_block(side_pos);
         if mchprs_redstone::is_diode(side_block)
             && provides_weak_power(side_block, side.block_face())
         {
@@ -230,7 +263,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
 
     fn search_comparator_side(&mut self, id: NodeIdx, pos: BlockPos, side: BlockDirection) {
         let side_pos = pos.offset(side.block_face());
-        let side_block = self.world.get_block(side_pos);
+        let side_block = self.block_lookup_cache.get_block(side_pos);
         if (mchprs_redstone::is_diode(side_block)
             && provides_weak_power(side_block, side.block_face()))
             || matches!(side_block, Block::RedstoneBlock { .. })
@@ -246,7 +279,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
         match Block::from_id(block_id) {
             Block::RedstoneTorch { .. } => {
                 let bottom_pos = pos.offset(BlockFace::Bottom);
-                let bottom_block = self.world.get_block(bottom_pos);
+                let bottom_block = self.block_lookup_cache.get_block(bottom_pos);
                 self.get_redstone_links(
                     bottom_block,
                     BlockFace::Top,
@@ -259,7 +292,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
             }
             Block::RedstoneWallTorch { facing, .. } => {
                 let wall_pos = pos.offset(facing.opposite().block_face());
-                let wall_block = self.world.get_block(wall_pos);
+                let wall_block = self.block_lookup_cache.get_block(wall_pos);
                 self.get_redstone_links(
                     wall_block,
                     facing.opposite().block_face(),
@@ -277,7 +310,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
                 self.search_comparator_side(id, pos, facing.rotate_ccw());
 
                 let input_pos = pos.offset(facing.block_face());
-                let input_block = self.world.get_block(input_pos);
+                let input_block = self.block_lookup_cache.get_block(input_pos);
                 if comparator::has_override(input_block) {
                     self.graph
                         .add_edge(self.pos_map[&input_pos], id, CompileLink::default(0));
@@ -298,7 +331,7 @@ impl<'a, W: World> InputSearchState<'a, W> {
             Block::RedstoneLamp { .. } | Block::IronTrapdoor { .. } | Block::NoteBlock { .. } => {
                 for face in &BlockFace::values() {
                     let neighbor_pos = pos.offset(*face);
-                    let neighbor_block = self.world.get_block(neighbor_pos);
+                    let neighbor_block = self.block_lookup_cache.get_block(neighbor_pos);
                     self.get_redstone_links(
                         neighbor_block,
                         *face,
@@ -326,24 +359,28 @@ impl<'a, W: World> InputSearchState<'a, W> {
     }
 }
 
-fn is_wire(world: &impl World, pos: BlockPos) -> bool {
-    matches!(world.get_block(pos), Block::RedstoneWire { .. })
+fn is_wire(block: Block) -> bool {
+    matches!(block, Block::RedstoneWire { .. })
 }
 
+/// Returns `true` if the given block provides either weak or strong power to the given side.
+/// Note that `side` is the side of the block receiving power, not the side of the block providing power.
 fn provides_weak_power(block: Block, side: BlockFace) -> bool {
     match block {
         Block::RedstoneTorch { .. } => side != BlockFace::Top,
-        Block::RedstoneWallTorch { facing, .. } if facing.block_face() != side => true,
+        Block::RedstoneWallTorch { facing, .. } => facing.block_face() != side,
         Block::RedstoneBlock {} => true,
         Block::Lever { .. } => true,
         Block::StoneButton { .. } => true,
         Block::StonePressurePlate { .. } => true,
-        Block::RedstoneRepeater { repeater } if repeater.facing.block_face() == side => true,
-        Block::RedstoneComparator { comparator } if comparator.facing.block_face() == side => true,
+        Block::RedstoneRepeater { repeater } => repeater.facing.block_face() == side,
+        Block::RedstoneComparator { comparator } => comparator.facing.block_face() == side,
         _ => false,
     }
 }
 
+/// Returns `true` if the given block provides strong power to the given side.
+/// Note that `side` is the side of the block receiving power, not the side of the block providing power.
 fn provides_strong_power(block: Block, side: BlockFace) -> bool {
     match block {
         Block::RedstoneTorch { .. } if side == BlockFace::Bottom => true,
@@ -359,8 +396,8 @@ fn provides_strong_power(block: Block, side: BlockFace) -> bool {
             BlockFace::Bottom => button.face == ButtonFace::Ceiling,
             _ => button.face == ButtonFace::Wall && button.facing == side.unwrap_direction(),
         },
-        Block::RedstoneRepeater { .. } => provides_weak_power(block, side),
-        Block::RedstoneComparator { .. } => provides_weak_power(block, side),
+        Block::RedstoneRepeater { repeater } => repeater.facing.block_face() == side,
+        Block::RedstoneComparator { comparator } => comparator.facing.block_face() == side,
         _ => false,
     }
 }

--- a/crates/redstone/src/lib.rs
+++ b/crates/redstone/src/lib.rs
@@ -27,7 +27,7 @@ fn get_weak_power(
     dust_power: bool,
 ) -> u8 {
     match block {
-        Block::RedstoneTorch { lit: true } => 15,
+        Block::RedstoneTorch { lit: true } if side != BlockFace::Top => 15,
         Block::RedstoneWallTorch { lit: true, facing } if facing.block_face() != side => 15,
         Block::RedstoneBlock {} => 15,
         Block::StonePressurePlate { powered: true } => 15,

--- a/tests/components.rs
+++ b/tests/components.rs
@@ -3,7 +3,7 @@ use common::*;
 
 use mchprs_blocks::blocks::Block;
 use mchprs_blocks::BlockDirection;
-use mchprs_world::World;
+use mchprs_world::{TickPriority, World};
 
 test_all_backends!(lever_on_off);
 fn lever_on_off(backend: TestBackend) {
@@ -181,4 +181,21 @@ fn wire_no_reach(backend: TestBackend) {
     runner.check_block_powered(trapdoor_pos, false);
     runner.use_block(lever_pos);
     runner.check_block_powered(trapdoor_pos, false);
+}
+
+test_all_backends!(ground_torch_does_not_power_block_below);
+/// https://github.com/MCHPR/MCHPRS/issues/218
+fn ground_torch_does_not_power_block_below(backend: TestBackend) {
+    let torch_pos = pos(0, 1, 0);
+    let lamp_pos = pos(0, 0, 0);
+
+    let mut world = TestWorld::new(1);
+    world.set_block(lamp_pos, Block::RedstoneLamp { lit: true });
+    world.set_block(torch_pos, Block::RedstoneTorch { lit: true });
+
+    world.schedule_tick(lamp_pos, 1, TickPriority::Normal);
+
+    let mut runner = BackendRunner::new(world, backend);
+    runner.tick();
+    runner.check_block_powered(lamp_pos, false);
 }


### PR DESCRIPTION
- Made `provides_weak_power` and `provides_strong_power` free functions as they don't use `&self`.
- Use linear search instead of hashmap lookup for BFS during redstone wire discovery.
- Cache recently queried blocks to avoid a lot of (but not all) duplicate queries. The majority of the speedup comes from this change.
- Also fix #218 because I'm already making changes to that code section anyway.

This PR significantly reduces the compile time of redstone in all of my tests. Example:

| [frostbyte-cpu](https://www.planetminecraft.com/project/frostbyte-a-16-bit-minecraft-cpu-with-just-redstone/) | master | this pr |
| --- | --- | --- |
| /rp c | 5.1045 s | 1.8972 s |
| /rp c -io | 1.0767 s | 0.5811 s |