### PR TITLE
Remove redundant comparator inputs

### DIFF
--- a/crates/redpiler/src/compile_graph.rs
+++ b/crates/redpiler/src/compile_graph.rs
@@ -89,7 +89,7 @@ impl CompileNode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LinkType {
     Default,
     Side,

--- a/crates/redpiler/src/passes/mod.rs
+++ b/crates/redpiler/src/passes/mod.rs
@@ -8,6 +8,7 @@ mod export_graph;
 mod identify_nodes;
 mod input_search;
 mod prune_orphans;
+mod redundant_links;
 mod unreachable_output;
 
 use mchprs_world::World;
@@ -30,6 +31,7 @@ pub const fn make_default_pass_manager<'w, W: World>() -> PassManager<'w, W> {
         &clamp_weights::ClampWeights,
         &dedup_links::DedupLinks,
         &constant_fold::ConstantFold,
+        &redundant_links::PruneRedundantLinks,
         &analysis::ss_range_analysis::SSRangeAnalysis,
         &unreachable_output::UnreachableOutput,
         &constant_coalesce::ConstantCoalesce,

--- a/crates/redpiler/src/passes/redundant_links.rs
+++ b/crates/redpiler/src/passes/redundant_links.rs
@@ -1,0 +1,108 @@
+use std::collections::hash_map::Entry;
+
+use super::Pass;
+use crate::compile_graph::{CompileGraph, LinkType, NodeIdx, NodeType};
+use crate::passes::AnalysisInfos;
+use crate::{CompilerInput, CompilerOptions};
+use mchprs_blocks::blocks::ComparatorMode;
+use mchprs_world::World;
+use petgraph::visit::EdgeRef;
+use petgraph::Direction;
+use rustc_hash::FxHashMap;
+use tracing::trace;
+
+pub struct PruneRedundantLinks;
+
+impl<W: World> Pass<W> for PruneRedundantLinks {
+    fn run_pass(
+        &self,
+        graph: &mut CompileGraph,
+        _: &CompilerOptions,
+        _: &CompilerInput<'_, W>,
+        _: &mut AnalysisInfos,
+    ) {
+        let mut num_edges_pruned = 0;
+        let node_indices = graph.node_indices().collect::<Vec<_>>();
+        for idx in node_indices {
+            num_edges_pruned += match graph[idx].ty {
+                NodeType::Comparator { mode, .. } => prune_comparator_inputs(graph, idx, mode),
+                _ => 0,
+            };
+        }
+        trace!("Removed {num_edges_pruned} edges.");
+    }
+
+    fn status_message(&self) -> &'static str {
+        "Pruning redundant links"
+    }
+}
+
+/// Whenever a node has links to both the default input and the side input of a comparator,
+/// only one of those links actually has an effect on the comparator (dominating link).
+/// The other link's effect is always cancelled out by the dominating link.
+/// This function determines the dominating link and removes the other.
+///
+/// The case where a node connects to both the default input and side input of a comparator is most
+/// commonly seen in XOR gates implemented by 2 comparators in subtract mode.
+fn prune_comparator_inputs(
+    graph: &mut CompileGraph,
+    idx: NodeIdx,
+    comparator_mode: ComparatorMode,
+) -> usize {
+    let mut input_distances: FxHashMap<(NodeIdx, LinkType), u8> = FxHashMap::default();
+    for edge in graph.edges_directed(idx, Direction::Incoming) {
+        match input_distances.entry((edge.source(), edge.weight().ty)) {
+            Entry::Occupied(occupied) => {
+                let cur_distance = occupied.into_mut();
+                *cur_distance = std::cmp::min(*cur_distance, edge.weight().ss);
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(edge.weight().ss);
+            }
+        };
+    }
+
+    let mut edges_to_be_removed = Vec::new();
+    for edge in graph.edges_directed(idx, Direction::Incoming) {
+        let default_distance = *input_distances
+            .get(&(edge.source(), LinkType::Default))
+            .unwrap_or(&u8::MAX);
+        let side_distance = *input_distances
+            .get(&(edge.source(), LinkType::Side))
+            .unwrap_or(&u8::MAX);
+        let dominating_input =
+            dominating_comparator_input(comparator_mode, default_distance, side_distance);
+        if edge.weight().ty != dominating_input {
+            edges_to_be_removed.push(edge.id());
+        }
+    }
+
+    let num_edges_pruned = edges_to_be_removed.len();
+    for edge in edges_to_be_removed {
+        graph.remove_edge(edge);
+    }
+    num_edges_pruned
+}
+
+fn dominating_comparator_input(
+    comparator_mode: ComparatorMode,
+    default_distance: u8,
+    side_distance: u8,
+) -> LinkType {
+    match comparator_mode {
+        ComparatorMode::Compare => {
+            if default_distance <= side_distance {
+                LinkType::Default
+            } else {
+                LinkType::Side
+            }
+        }
+        ComparatorMode::Subtract => {
+            if side_distance <= default_distance {
+                LinkType::Side
+            } else {
+                LinkType::Default
+            }
+        }
+    }
+}

--- a/crates/redpiler/src/passes/redundant_links.rs
+++ b/crates/redpiler/src/passes/redundant_links.rs
@@ -70,9 +70,9 @@ fn prune_comparator_inputs(
         let side_distance = *input_distances
             .get(&(edge.source(), LinkType::Side))
             .unwrap_or(&u8::MAX);
-        let dominating_input =
-            dominating_comparator_input(comparator_mode, default_distance, side_distance);
-        if edge.weight().ty != dominating_input {
+        let dominated_input =
+            dominated_comparator_input(comparator_mode, default_distance, side_distance);
+        if Some(edge.weight().ty) == dominated_input {
             edges_to_be_removed.push(edge.id());
         }
     }
@@ -84,24 +84,24 @@ fn prune_comparator_inputs(
     num_edges_pruned
 }
 
-fn dominating_comparator_input(
+fn dominated_comparator_input(
     comparator_mode: ComparatorMode,
     default_distance: u8,
     side_distance: u8,
-) -> LinkType {
+) -> Option<LinkType> {
     match comparator_mode {
         ComparatorMode::Compare => {
             if default_distance <= side_distance {
-                LinkType::Default
+                Some(LinkType::Side)
             } else {
-                LinkType::Side
+                Some(LinkType::Default)
             }
         }
         ComparatorMode::Subtract => {
             if side_distance <= default_distance {
-                LinkType::Side
+                Some(LinkType::Default)
             } else {
-                LinkType::Default
+                None
             }
         }
     }

--- a/crates/redpiler/src/passes/redundant_links.rs
+++ b/crates/redpiler/src/passes/redundant_links.rs
@@ -25,7 +25,11 @@ impl<W: World> Pass<W> for PruneRedundantLinks {
         let node_indices = graph.node_indices().collect::<Vec<_>>();
         for idx in node_indices {
             num_edges_pruned += match graph[idx].ty {
-                NodeType::Comparator { mode, .. } => prune_comparator_inputs(graph, idx, mode),
+                NodeType::Comparator {
+                    mode,
+                    far_input: None,
+                    ..
+                } => prune_comparator_inputs(graph, idx, mode),
                 _ => 0,
             };
         }


### PR DESCRIPTION
Whenever a node has links to both the default input and the side input of a comparator, one of those links is often completely irrelevant because it gets cancelled out by the other. This PR adds a new optimization pass to remove those redundant links.

IRIS Mandelbrot benchmark:
```
master:
DONE in 37.298039635s processing 135000000 ticks, effective rtps: 3619493.177687487
DONE in 38.017733937s processing 135000000 ticks, effective rtps: 3550974.4011495104
DONE in 37.464473919s processing 135000000 ticks, effective rtps: 3603413.7378220367
DONE in 37.449590958s processing 135000000 ticks, effective rtps: 3604845.7819313304

remove-redundant-comparator-inputs:
DONE in 37.079987871s processing 135000000 ticks, effective rtps: 3640777.8899405347
DONE in 37.288002602s processing 135000000 ticks, effective rtps: 3620467.4581512464
DONE in 37.474739122s processing 135000000 ticks, effective rtps: 3602426.678955761
DONE in 37.189786422s processing 135000000 ticks, effective rtps: 3630028.913533619
```