### PR TITLE
TickScheduler: replace Queues.drain_iter with drain_each

### DIFF
--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -25,8 +25,13 @@ use tracing::{debug, warn};
 struct Queues([Vec<NodeId>; TickScheduler::NUM_PRIORITIES]);
 
 impl Queues {
-    fn drain_iter(&mut self) -> impl Iterator<Item = NodeId> + '_ {
-        self.0.iter_mut().flat_map(|q| q.drain(..))
+    #[inline(always)]
+    fn drain_each<F: FnMut(NodeId)>(&mut self, mut f: F) {
+        for q in self.0.iter_mut() {
+            for n in q.drain(..) {
+                f(n);
+            }
+        }
     }
 }
 
@@ -233,9 +238,9 @@ impl JITBackend for DirectBackend {
     fn tick(&mut self) {
         let mut queues = self.scheduler.queues_this_tick();
 
-        for node_id in queues.drain_iter() {
+        queues.drain_each(|node_id| {
             self.tick_node(node_id);
-        }
+        });
 
         self.scheduler.end_tick(queues);
     }


### PR DESCRIPTION
This simple change speeds up iris mandlebrot by about 11%

Since `drain_each` is only used in one place we could also simply inline it, but I kept it a function since we used a function for this iteration before.