### PR TITLE
Incorporate pending ticks into compile_graph::NodeState

### DIFF
--- a/crates/redpiler/src/compile_graph.rs
+++ b/crates/redpiler/src/compile_graph.rs
@@ -1,5 +1,6 @@
 use mchprs_blocks::blocks::{ComparatorMode, Instrument};
 use mchprs_blocks::BlockPos;
+use mchprs_world::{TickEntry, TickPriority};
 use petgraph::stable_graph::{NodeIndex, StableGraph};
 use smallvec::SmallVec;
 
@@ -51,6 +52,7 @@ pub struct NodeState {
     pub powered: bool,
     pub repeater_locked: bool,
     pub output_strength: u8,
+    pending_ticks: Option<(TickPriority, u32)>,
 }
 
 impl NodeState {
@@ -67,6 +69,7 @@ impl NodeState {
             powered,
             repeater_locked: locked,
             output_strength: if powered { 15 } else { 0 },
+            ..Default::default()
         }
     }
 
@@ -104,6 +107,15 @@ pub struct CompileNode {
 impl CompileNode {
     pub fn is_removable(&self) -> bool {
         !self.is_input && !self.is_output
+    }
+
+    pub fn add_pending_tick(&mut self, tick: &TickEntry) {
+        assert!(!self.has_pending_ticks());
+        self.state.pending_ticks = Some((tick.tick_priority, tick.ticks_left));
+    }
+
+    pub fn has_pending_ticks(&self) -> bool {
+        self.state.pending_ticks.is_some()
     }
 }
 

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -147,7 +147,11 @@ impl Compiler {
         debug!("Starting compile");
         let start = Instant::now();
 
-        let input = CompilerInput { world, bounds, pending_ticks: &ticks };
+        let input = CompilerInput {
+            world,
+            bounds,
+            pending_ticks: &ticks,
+        };
         let registry = PassRegistry::default();
         let pass_pipeline = passes::build_pass_pipeline::<W>(&registry, &options);
         let graph =

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -147,7 +147,7 @@ impl Compiler {
         debug!("Starting compile");
         let start = Instant::now();
 
-        let input = CompilerInput { world, bounds };
+        let input = CompilerInput { world, bounds, pending_ticks: &ticks };
         let registry = PassRegistry::default();
         let pass_pipeline = passes::build_pass_pipeline::<W>(&registry, &options);
         let graph =
@@ -256,6 +256,7 @@ impl Compiler {
 pub struct CompilerInput<'w, W: World> {
     pub world: &'w W,
     pub bounds: (BlockPos, BlockPos),
+    pub pending_ticks: &'w [TickEntry],
 }
 
 #[cfg(test)]

--- a/crates/redpiler/src/passes/frontend/identify_nodes.rs
+++ b/crates/redpiler/src/passes/frontend/identify_nodes.rs
@@ -54,6 +54,11 @@ impl<W: World> Pass<W> for IdentifyNodes {
         for pos in second_pass {
             apply_annotations(graph, options, &first_pass, plot, pos);
         }
+
+        for tick in input.pending_ticks {
+            let id = first_pass[&tick.pos];
+            graph[id].add_pending_tick(tick);
+        }
     }
 
     fn status_message(&self) -> &'static str {

--- a/crates/redpiler/src/passes/opt/coalesce.rs
+++ b/crates/redpiler/src/passes/opt/coalesce.rs
@@ -83,6 +83,7 @@ fn coalesce_outgoing(graph: &mut CompileGraph, source_idx: NodeIdx, into_idx: No
         let into = &graph[into_idx];
 
         if dest.ty == into.ty
+            && dest.state == into.state
             && dest.is_removable()
             && graph
                 .neighbors_directed(dest_idx, Direction::Incoming)

--- a/crates/rilc/src/compile.rs
+++ b/crates/rilc/src/compile.rs
@@ -45,6 +45,7 @@ pub fn compile(input_path: &Path, output_path: &Option<PathBuf>, options: &Compi
         let input = CompilerInput {
             world: &world,
             bounds,
+            pending_ticks: &[]
         };
 
         let monitor = Arc::new(TaskMonitor::default());

--- a/crates/rilc/src/compile.rs
+++ b/crates/rilc/src/compile.rs
@@ -45,7 +45,7 @@ pub fn compile(input_path: &Path, output_path: &Option<PathBuf>, options: &Compi
         let input = CompilerInput {
             world: &world,
             bounds,
-            pending_ticks: &[]
+            pending_ticks: &[],
         };
 
         let monitor = Arc::new(TaskMonitor::default());

--- a/crates/rilc/src/test.rs
+++ b/crates/rilc/src/test.rs
@@ -55,6 +55,7 @@ fn run_test(
     let input = CompilerInput {
         world: &world,
         bounds,
+        pending_ticks: &[]
     };
 
     let registry = PassRegistry::default();

--- a/crates/rilc/src/test.rs
+++ b/crates/rilc/src/test.rs
@@ -55,7 +55,7 @@ fn run_test(
     let input = CompilerInput {
         world: &world,
         bounds,
-        pending_ticks: &[]
+        pending_ticks: &[],
     };
 
     let registry = PassRegistry::default();


### PR DESCRIPTION
split out from #222 

A component that has a pending tick should (mostly) not be merged with one that doesn't.

## open questions
- [ ] should `constant_fold` and `constant_coalesce` be merged together by making use of `ss_range_analysis` ?
- [ ] should the pending ticks be passed as an extra argument like they are now or should they be extracted from the world?

## todo before merge
- [x] apply to  `coalesce` pass
- [ ] add tests that check `coalesce` respect this
- [ ] apply to `ss_range_analysis`
- [ ] apply to `constant_fold` and  `constant_coalesce` 
- [ ] add tests that check `constant_fold` and  `constant_coalesce`  respect this
- [ ] apply to ril