### PR TITLE
mchprs_world: remove networking from default features

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,7 +17,7 @@ include.workspace = true
 mchprs_proc_macros = { path = "../proc_macros" }
 mchprs_save_data = { path = "../save_data" }
 mchprs_blocks = { path = "../blocks" }
-mchprs_world = { path = "../world" }
+mchprs_world = { path = "../world", features = ["networking"] }
 mchprs_utils = { path = "../utils" }
 mchprs_network = { path = "../network" }
 mchprs_text = { path = "../text" }

--- a/crates/world/Cargo.toml
+++ b/crates/world/Cargo.toml
@@ -21,6 +21,5 @@ rustc-hash = { workspace = true }
 hematite-nbt = { workspace = true }
 
 [features]
-default = ["networking"]
 networking = ["dep:mchprs_network"]
 testing = []


### PR DESCRIPTION
Networking being a default feature in `mchprs_world` makes it difficult to use `redpiler` in a project compiling to WASM, since its difficult to remove features from subdependencies and WASM doesn't support some of the features used in the `mchprs_network` crate.

Alternatively all dependents of `mchprs_world` can have `default_features = false` added, which would be better if there are any crates depending on this being a default feature.