### PR TITLE
Sort properties by their change interval in the state list

### DIFF
--- a/crates/block_data_gen/src/main.rs
+++ b/crates/block_data_gen/src/main.rs
@@ -173,12 +173,13 @@ fn process_block(
     props.sort_by_cached_key(|prop| {
         let name = prop.name.as_str();
 
-        let last = json.states.first().unwrap().properties.as_ref().unwrap()[name].as_str();
+        let previous_state =
+            json.states.first().unwrap().properties.as_ref().unwrap()[name].as_str();
 
         let interval = json
             .states
             .iter()
-            .position(|state| state.properties.as_ref().unwrap()[name] != last)
+            .position(|state| state.properties.as_ref().unwrap()[name] != previous_state)
             .unwrap();
 
         usize::MAX - interval

--- a/crates/block_data_gen/src/main.rs
+++ b/crates/block_data_gen/src/main.rs
@@ -172,11 +172,14 @@ fn process_block(
     // Sort properties by their change interval in the state list in ascending order.
     props.sort_by_cached_key(|prop| {
         let name = prop.name.as_str();
-        
-        let last = json.states.first().unwrap()
-            .properties.as_ref().unwrap()[name].as_str();
-        
-        let interval = json.states.iter().position(|state| state.properties.as_ref().unwrap()[name] != last).unwrap();
+
+        let last = json.states.first().unwrap().properties.as_ref().unwrap()[name].as_str();
+
+        let interval = json
+            .states
+            .iter()
+            .position(|state| state.properties.as_ref().unwrap()[name] != last)
+            .unwrap();
 
         usize::MAX - interval
     });

--- a/crates/block_data_gen/src/main.rs
+++ b/crates/block_data_gen/src/main.rs
@@ -168,6 +168,19 @@ fn process_block(
             ),
         };
     }
+
+    // Sort properties by their change interval in the state list in ascending order.
+    props.sort_by_cached_key(|prop| {
+        let name = prop.name.as_str();
+        
+        let last = json.states.first().unwrap()
+            .properties.as_ref().unwrap()[name].as_str();
+        
+        let interval = json.states.iter().position(|state| state.properties.as_ref().unwrap()[name] != last).unwrap();
+
+        usize::MAX - interval
+    });
+
     let mut attrs = BlockAttrs::default();
     for attr in attrs_str.split(',').filter(|s| !s.is_empty()) {
         match attr {


### PR DESCRIPTION
The state list determines which ids represent which state, not the order of the properties.
This Pull Request sorts the properties to match the state list so any code that depends on the property order to know the ID's is valid.

This currently does not effect the any implemented blocks (hence only the generator is updated) but this does fix the order for for-example the `piston_head` block.

Ideally we'd also do some validation in this part of the code so its easier to tell when `complex_transform` is necessary in `gen_info.yaml`.