### PR TITLE
docs: fix whitelist description typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The folowing options are available at the toplevel (under no header):
 | `chat_format` | How to format chat message interpolating `username` and `message` with curly braces | `<{username}> {message}` |
 | `max_players` | Maximum number of simultaneous players | `99999` |
 | `view_distance` | Maximal distance (in chunks) between players and loaded chunks | `8` |
-| `whitelist` | Whether or not the whitelist (in `whitelist.json`) shoud be enabled | `false` |
+| `whitelist` | Whether or not the whitelist (in `whitelist.json`) should be enabled | `false` |
 | `schemati` | Mimic the verification and directory layout used by the Open Redstone Engineers [Schemati plugin](https://github.com/OpenRedstoneEngineers/Schemati) | `false` |
 | `block_in_hitbox` | Allow placing blocks inside of players (hitbox logic is simplified) | `true` |
 | `auto_redpiler` | Use redpiler automatically | `false` |


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `shoud` to `should` in the whitelist configuration description.

Fixes #202

## Test plan
- static validation: `shoud` appeared 1 time(s) in `README.md` before replacement.
- static validation: `shoud` is absent and `should` is present in `README.md` after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
