### PR TITLE
Retain input nodes in prune_orphans pass

### DIFF
--- a/crates/redpiler/src/passes/opt/prune_orphans.rs
+++ b/crates/redpiler/src/passes/opt/prune_orphans.rs
@@ -41,7 +41,13 @@ impl<W: World> Pass<W> for PruneOrphans {
             }
         }
 
-        graph.retain_nodes(|_, idx| visited[idx.index()]);
+        graph.retain_nodes(|g, idx| {
+            let visible = visited[idx.index()];
+            let is_input = g[idx].is_input;
+
+            // Retain inputs so they can be updated when used
+            visible || is_input
+        });
     }
 
     fn status_message(&self) -> &'static str {


### PR DESCRIPTION
When the `-i` flag was used the plot could crash when an input was used that doesn't contribute to an output.
retaining the inputs should prevent this crash and also allow the component to properly update.

ideally if a block is missing in a backend it should error gracefully but this is not neccesary to fix this issue, some work on this can be found here https://github.com/BramOtte/MCHPRS/tree/retain-inputs 