### PR TITLE
Fix outdated block IDs in tests and test the whole workspace in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run clippy
         # If we ever get around to fix everything clippy complains about we can start failing on warning via: -- -D warnings
-        run: cargo clippy --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   test:
     name: Run tests
@@ -55,7 +55,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run rust tests
-        run: cargo test --all-features --all-targets
+        run: cargo test --workspace --all-features --all-targets
 
       - name: Run redpiler tests
         run: cargo run -p rilc test crates/redpiler/ril_tests

--- a/crates/blocks/src/blocks/mod.rs
+++ b/crates/blocks/src/blocks/mod.rs
@@ -241,7 +241,7 @@ impl Block {
 fn repeater_id_test() {
     let original = Block::Repeater(Repeater::new(3, BlockDirection::West, true, false));
     let id = original.get_id();
-    assert_eq!(id, 4141);
+    assert_eq!(id, 5922);
     let new = Block::from_id(id);
     assert_eq!(new, original);
 }
@@ -254,7 +254,7 @@ fn comparator_id_test() {
         false,
     ));
     let id = original.get_id();
-    assert_eq!(id, 6895);
+    assert_eq!(id, 9186);
     let new = Block::from_id(id);
     assert_eq!(new, original);
 }


### PR DESCRIPTION
The two block ID tests in `mchprs_blocks` still expect the IDs from before the block data update and currently fail on master.
Root `cargo test --all-features --all-targets` only runs the root package's tests, so CI missed these failures.

I updated the two IDs and added `--workspace` to the test and clippy steps.
