### PR TITLE
Fix comparator block entity syncing

### DIFF
--- a/crates/blocks/src/block_entities.rs
+++ b/crates/blocks/src/block_entities.rs
@@ -155,9 +155,13 @@ impl BlockEntity {
     pub fn from_nbt(id: &str, nbt: &HashMap<String, nbt::Value>) -> Option<BlockEntity> {
         use nbt::Value;
         match id.trim_start_matches("minecraft:") {
-            "comparator" => Some(BlockEntity::Comparator {
-                output_strength: *nbt_unwrap_val!(&nbt["OutputSignal"], Value::Int) as u8,
-            }),
+            "comparator" => {
+                let output_strength = match nbt.get("OutputSignal") {
+                    Some(Value::Int(value)) => (*value).clamp(0, 15) as u8,
+                    _ => 0,
+                };
+                Some(BlockEntity::Comparator { output_strength })
+            }
             "furnace" => BlockEntity::load_container(
                 nbt_unwrap_val!(&nbt["Items"], Value::List),
                 ContainerType::Furnace,

--- a/crates/redpiler/src/backend/direct/mod.rs
+++ b/crates/redpiler/src/backend/direct/mod.rs
@@ -182,26 +182,11 @@ impl JITBackend for DirectBackend {
         debug!("Node {:?}: {:#?}", node_id, self.nodes[*node_id]);
     }
 
-    fn reset<W: World>(&mut self, world: &mut W, io_only: bool) {
+    fn reset<W: World>(&mut self, world: &mut W) {
+        self.flush(world, false);
         self.scheduler.reset(world, &self.blocks);
-
-        let nodes = std::mem::take(&mut self.nodes);
-
-        for (i, node) in nodes.into_inner().iter().enumerate() {
-            for (pos, block) in self.blocks[i].iter().copied() {
-                if matches!(node.ty, NodeType::Comparator { .. }) {
-                    let block_entity = BlockEntity::Comparator {
-                        output_strength: node.output_power,
-                    };
-                    world.set_block_entity(pos, block_entity);
-                }
-
-                if io_only && !node.is_io {
-                    world.set_block(pos, block);
-                }
-            }
-        }
-
+        self.nodes = Nodes::default();
+        self.blocks.clear();
         self.forward_links.clear();
         self.pos_map.clear();
         self.noteblock_info.clear();
@@ -277,6 +262,14 @@ impl JITBackend for DirectBackend {
                     repeater.locked = node.locked;
                 }
                 world.set_block(*pos, *block);
+                if matches!(block, Block::Comparator(_)) {
+                    world.set_block_entity(
+                        *pos,
+                        BlockEntity::Comparator {
+                            output_strength: node.output_power,
+                        },
+                    );
+                }
             }
         }
     }

--- a/crates/redpiler/src/backend/direct/node.rs
+++ b/crates/redpiler/src/backend/direct/node.rs
@@ -43,10 +43,6 @@ impl Nodes {
     pub fn inner_mut(&mut self) -> &mut [Node] {
         &mut self.nodes
     }
-
-    pub fn into_inner(self) -> Box<[Node]> {
-        self.nodes
-    }
 }
 
 impl Index<NodeId> for Nodes {

--- a/crates/redpiler/src/backend/mod.rs
+++ b/crates/redpiler/src/backend/mod.rs
@@ -29,7 +29,7 @@ pub trait JITBackend {
     fn on_use_block(&mut self, pos: BlockPos);
     fn set_pressure_plate(&mut self, pos: BlockPos, powered: bool);
     fn flush<W: World>(&mut self, world: &mut W, io_only: bool);
-    fn reset<W: World>(&mut self, world: &mut W, io_only: bool);
+    fn reset<W: World>(&mut self, world: &mut W);
     fn has_pending_ticks(&self) -> bool;
     /// Inspect block for debugging
     fn inspect(&mut self, pos: BlockPos);

--- a/crates/redpiler/src/compile_graph/mod.rs
+++ b/crates/redpiler/src/compile_graph/mod.rs
@@ -81,10 +81,10 @@ impl NodeState {
         }
     }
 
-    pub fn comparator(powered: bool, ss: u8) -> NodeState {
+    pub fn comparator(output_strength: u8) -> NodeState {
         NodeState {
-            powered,
-            output_strength: ss,
+            powered: output_strength > 0,
+            output_strength,
             ..Default::default()
         }
     }

--- a/crates/redpiler/src/lib.rs
+++ b/crates/redpiler/src/lib.rs
@@ -201,7 +201,7 @@ impl Compiler {
         if self.is_active {
             self.is_active = false;
             if let Some(backend) = &mut self.backend {
-                backend.reset(world, self.options.io_only)
+                backend.reset(world)
             }
         }
 

--- a/crates/redpiler/src/passes/frontend/identify_nodes.rs
+++ b/crates/redpiler/src/passes/frontend/identify_nodes.rs
@@ -144,7 +144,6 @@ fn identify_block<W: World>(
                 ),
             },
             NodeState::comparator(
-                comparator.powered,
                 if let Some(BlockEntity::Comparator { output_strength }) =
                     world.get_block_entity(pos)
                 {

--- a/crates/redpiler/src/ril.rs
+++ b/crates/redpiler/src/ril.rs
@@ -893,7 +893,7 @@ impl Parser {
                 ast::Component {
                     name,
                     inputs,
-                    node_state: NodeState::comparator(output_strength > 0, output_strength as u8),
+                    node_state: NodeState::comparator(output_strength as u8),
                     node_ty: NodeType::Comparator {
                         mode,
                         far_input,

--- a/crates/redstone/src/lib.rs
+++ b/crates/redstone/src/lib.rs
@@ -394,8 +394,8 @@ pub fn on_use(block: Block, world: &mut impl World, pos: BlockPos) -> bool {
         Block::Comparator(comparator) => {
             let mut comparator = comparator;
             comparator.mode = comparator.mode.toggle();
-            comparator::tick(comparator, world, pos);
             world.set_block(pos, Block::Comparator(comparator));
+            comparator::tick(comparator, world, pos);
             true
         }
         Block::Lever {


### PR DESCRIPTION
Comparator block entities weren't being updated when Redpiler flushed, so saves and copies could pick up old output strengths.

`flush` now writes the block entity together with the block, and `reset` reuses `flush`.
I also fixed the powered state being overwritten with the pre-tick value when toggling a comparator by hand.
Loading comparators without `OutputSignal` used to panic and now defaults to 0.

`--io-only` still leaves internal state frozen until reset, not sure how we would fix that.
Comparators removed by optimization can still have stale block entity data after reset.
